### PR TITLE
Refactor of petri net factory

### DIFF
--- a/src/Petri/Arc.java
+++ b/src/Petri/Arc.java
@@ -53,41 +53,43 @@ public class Arc {
 	};
 	
 	private String id;
-	private String id_source;
-	private String id_target;
+	private PetriNode source;
+	private PetriNode target;
 	private Integer weight;
 	/** Type of arc from {@link ArcType} */
 	private ArcType type;
 	
 	/**
 	 * @param _id Unique id to identify the arc
-	 * @param _id_source Unique id matching the arc's source
-	 * @param _id_target Unique id matching the arc's target
+	 * @param _source PetriNode object for arc's source
+	 * @param _target PetriNode object for arc's target
 	 * @param _weight A positive non-zero integer for the arc's weight
-	 * @throws IllegalArgumentException if the specified weight is less than one or if any field is null
+	 * @throws IllegalArgumentException if the specified weight is invalid or if any field is null
+	 * @see PetriNode
 	 */
-	public Arc(String _id, String _id_source, String _id_target, Integer _weight) throws IllegalArgumentException {
-		this(_id, _id_source, _id_target, _weight, ArcType.NORMAL);
+	public Arc(String _id, PetriNode _source, PetriNode _target, Integer _weight) throws IllegalArgumentException {
+		this(_id, _source, _target, _weight, ArcType.NORMAL);
 	}
 	
 	/**
 	 * @param _id Unique id to identify the arc
-	 * @param _id_source Unique id matching the arc's source
-	 * @param _id_target Unique id matching the arc's target
+	 * @param _source PetriNode object for arc's source
+	 * @param _target PetriNode object for arc's target
 	 * @param _weight A positive non-zero integer for the arc's weight. If _type is {@link ArcType#INHIBITOR}, _weight must be one
 	 * @param _type An {@link ArcType} type
-	 * @throws IllegalArgumentException if the specified weight is invalid or if any field is null 
+	 * @throws IllegalArgumentException if the specified weight is invalid or if any field is null
+	 * @see PetriNode 
 	 */
-	public Arc(String _id, String _id_source, String _id_target, Integer _weight, ArcType _type) throws IllegalArgumentException{
-		if( _id == null || _id_source == null || _id_target == null || _weight == null || _type == null){
+	public Arc(String _id, PetriNode _source, PetriNode _target, Integer _weight, ArcType _type) throws IllegalArgumentException{
+		if( _id == null || _source == null || _target == null || _weight == null || _type == null){
 			throw new IllegalArgumentException("Invalid null parameter recieved");
 		}
 		if(!isValidWeightForArc(_weight, _type)){
 			throw new IllegalArgumentException("Arc weight cannot be less that 1");
 		}
 		this.id = _id;
-		this.id_source = _id_source;
-		this.id_target = _id_target;
+		this.source = _source;
+		this.target = _target;
 		this.weight = _weight;
 		this.type = _type;
 	}
@@ -100,17 +102,17 @@ public class Arc {
 	}
 
 	/**
-	 * @return the arc's source's id
+	 * @return the arc's source
 	 */
-	public String getId_source() {
-		return id_source;
+	public PetriNode getSource() {
+		return source;
 	}
 
 	/**
-	 * @return the arc's target's id
+	 * @return the arc's target
 	 */
-	public String getId_target() {
-		return id_target;
+	public PetriNode getTarget() {
+		return target;
 	}
 
 	/**
@@ -120,10 +122,19 @@ public class Arc {
 		return id;
 	}
 	
+	/**
+	 * @return the arc type
+	 */
 	public ArcType getType(){
 		return type;
 	}
 	
+	/**
+	 * Checks is _weight is valid for an arc of type _type
+	 * @param _weight an Integer for the weight to test
+	 * @param _type the arc type to test
+	 * @return True if the weight is valid for the arc type
+	 */
 	private boolean isValidWeightForArc(Integer _weight, ArcType _type){
 		if(type == ArcType.INHIBITOR){
 			return _weight == 1;

--- a/src/Petri/Arc.java
+++ b/src/Petri/Arc.java
@@ -130,7 +130,7 @@ public class Arc {
 	}
 	
 	/**
-	 * Checks is _weight is valid for an arc of type _type
+	 * Checks if _weight is valid for an arc of type _type
 	 * @param _weight an Integer for the weight to test
 	 * @param _type the arc type to test
 	 * @return True if the weight is valid for the arc type

--- a/src/Petri/PTPetriNet.java
+++ b/src/Petri/PTPetriNet.java
@@ -7,7 +7,7 @@ public class PTPetriNet extends PetriNet{
 	 * @see PetriNet#PetriNet(Place[], Transition[], Arc[], Integer[], Integer[][], Integer[][], Integer[][])
 	 */
 	public PTPetriNet(Place[] _places, Transition[] _transitions, Arc[] _arcs, Integer[] _initialMarking,
-			Integer[][] _preI, Integer[][] _posI, Integer[][] _I, Integer[][] _inhibition, Integer[][] _resetMatrix) {
+			Integer[][] _preI, Integer[][] _posI, Integer[][] _I, Boolean[][] _inhibition, Boolean[][] _resetMatrix) {
 		super(_places, _transitions, _arcs, _initialMarking, _preI, _posI, _I, _inhibition, _resetMatrix);
 	}
 

--- a/src/Petri/PetriNet.java
+++ b/src/Petri/PetriNet.java
@@ -24,8 +24,8 @@ public abstract class PetriNet {
 	protected boolean[] automaticTransitions;
 	protected boolean[] informedTransitions;
 	/** Inhibition matrix used for inhibition logic */
-	protected Integer[][] inhibitionMatrix;
-	protected Integer[][] resetMatrix;
+	protected Boolean[][] inhibitionMatrix;
+	protected Boolean[][] resetMatrix;
 	protected boolean hasInhibitionArcs;
 	protected boolean hasResetArcs;
 	
@@ -60,7 +60,7 @@ public abstract class PetriNet {
 	 */
 	protected PetriNet(Place[] _places, Transition[] _transitions, Arc[] _arcs,
 			Integer[] _initialMarking, Integer[][] _preI, Integer[][] _posI, Integer[][] _I,
-			Integer[][] _inhibitionMatrix, Integer[][] _resetMatrix){
+			Boolean[][] _inhibitionMatrix, Boolean[][] _resetMatrix){
 		this.places = _places;
 		this.transitions = _transitions;
 		
@@ -133,7 +133,7 @@ public abstract class PetriNet {
 			places[i].setMarking(currentMarking[i]);
 		}
 		for(int i = 0; i < currentMarking.length; i++){
-			if(resetMatrix[i][transitionIndex] == 1){
+			if(resetMatrix[i][transitionIndex]){
 				currentMarking[i] = 0;
 			}
 		}
@@ -251,7 +251,7 @@ public abstract class PetriNet {
 		if(hasInhibitionArcs){
 			for(int i = 0; i < places.length; i++){
 				boolean emptyPlace = places[i].getMarking() == 0;
-				boolean placeInhibitsTransition = inhibitionMatrix[i][transitionIndex] > 0;
+				boolean placeInhibitsTransition = inhibitionMatrix[i][transitionIndex];
 				if(!emptyPlace && placeInhibitsTransition){
 					return false;
 				}
@@ -261,7 +261,7 @@ public abstract class PetriNet {
 			for(int i = 0; i < places.length; i++){
 				boolean emptyPlace = places[i].getMarking() == 0;
 				//resetMatrix should be a binary matrix, so it never should have an element with value grater than 1
-				boolean placeResetsTransition = resetMatrix[i][transitionIndex] > 0;
+				boolean placeResetsTransition = resetMatrix[i][transitionIndex];
 				if(placeResetsTransition && emptyPlace){
 					return false;
 				}
@@ -304,22 +304,22 @@ public abstract class PetriNet {
 	}
 	
 	/**
-	 * Checks if all elements in the matrix are zero.
+	 * Checks if all elements in the matrix are false.
 	 * This is used to know if the petri has the type of arcs described by the matrix semantics.
 	 * @param matrix specifies the kind of arcs
 	 * @return True if the net has inhibition arcs.
 	 */
-	protected boolean isMatrixNonZero(Integer[][] matrix){
+	protected boolean isMatrixNonZero(Boolean[][] matrix){
 		// if the matrix is null or if all elements are zeros
 		// the net does not have the type of arcs described by the matrix semantics
 		try{
 			// this trivial comparison is to throw a NullPointerException if matrix is null
 			matrix.equals(matrix);
 			boolean allZeros = true;
-			for( Integer[] row : matrix ){
+			for( Boolean[] row : matrix ){
 				// if hashset size is 1 all elements are equal
-				allZeros &= row[0] == 0 && 
-						new HashSet<Integer>(Arrays.asList(row)).size() == 1;
+				allZeros &= !row[0] &&
+						new HashSet<Boolean>(Arrays.asList(row)).size() == 1;
 				if(!allZeros){
 					return true;
 				}

--- a/src/Petri/PetriNetFactory.java
+++ b/src/Petri/PetriNetFactory.java
@@ -42,13 +42,14 @@ import Petri.Arc.ArcType;
 		 * makes and returns the petri described in the PNML file passed to the factory
 		 * @return PetriNet object containing info described in PNML file
 		 * @param petriNetType petri net type from enum type {@link petriNetType}
-		 * @throws CannotCreatePetriNetError If the parsed info has inconsistent data.
+		 * @throws CannotCreatePetriNetError If any a non supported arc type is given,
+		 * or if a transition that has a reset arc as input has another arc as input
 		 */
 		public PetriNet makePetriNet(petriNetType type) throws CannotCreatePetriNetError{
 			
 			Quartet<Place[], Transition[], Arc[], Integer[]> petriObjects = PNML2PNObjects();
 			Quintet<Integer[][], Integer[][], Integer[][], Integer[][], Integer[][]> petriMatrices = 
-					rdpObjects2Matrices(petriObjects.getValue0(), petriObjects.getValue1(), petriObjects.getValue2());
+					petriNetObjectsToMatrices(petriObjects.getValue0(), petriObjects.getValue1(), petriObjects.getValue2());
 			
 			switch(type){
 			case PT:
@@ -65,7 +66,7 @@ import Petri.Arc.ArcType;
 		 * extracts petri net info from PNML file given as argument and returns a 4-tuple containing
 		 * places, transitions, arcs and initial marking
 		 * @return a 4-tuple containig (places, transitions, arcs, initial marking)
-		 * @throws CannotCreatePetriNetError
+		 * @throws CannotCreatePetriNetError If an error occurs during parsing
 		 */
 		protected Quartet<Place[], Transition[], Arc[], Integer[]> PNML2PNObjects() throws CannotCreatePetriNetError{
 			try{
@@ -73,8 +74,8 @@ import Petri.Arc.ArcType;
 			
 				return ret.add(getMarkingFromPlaces(ret.getValue0()));
 			} catch (BadPNMLFormatException e){
-				throw new CannotCreatePetriNetError("Error creating petriNet due to PNML error. "
-						+ e.getMessage());
+				throw new CannotCreatePetriNetError("Error creating petriNet due to PNML error " + e.getClass().getSimpleName()
+						+ ". Message: " + e.getMessage());
 			}
 		}
 		
@@ -88,7 +89,7 @@ import Petri.Arc.ArcType;
 		 * or if a transition that has a reset arc as input has another arc as input
 		 * @see Petri.Arc.ArcType
 		 */
-		protected Quintet<Integer[][], Integer[][], Integer[][], Integer[][], Integer[][]> rdpObjects2Matrices(
+		protected Quintet<Integer[][], Integer[][], Integer[][], Integer[][], Integer[][]> petriNetObjectsToMatrices(
 				Place[] places, Transition[] transitions, Arc[] arcs) throws CannotCreatePetriNetError{
 			final int placesAmount = places.length;
 			final int transitionsAmount = transitions.length;

--- a/src/Petri/TimedPetriNet.java
+++ b/src/Petri/TimedPetriNet.java
@@ -12,7 +12,7 @@ public class TimedPetriNet extends PetriNet{
 	 * @see PetriNet#PetriNet(Place[], Transition[], Arc[], Integer[], Integer[][], Integer[][], Integer[][])
 	 */
 	public TimedPetriNet(Place[] _places, Transition[] _transitions, Arc[] _arcs, Integer[] _initialMarking,
-			Integer[][] _preI, Integer[][] _posI, Integer[][] _I, Integer[][] _inhibition, Integer[][] _resetMatrix) {
+			Integer[][] _preI, Integer[][] _posI, Integer[][] _I, Boolean[][] _inhibition, Boolean[][] _resetMatrix) {
 		super(_places, _transitions, _arcs, _initialMarking, _preI, _posI, _I, _inhibition, _resetMatrix);
 		enabledTransitions = new boolean[_transitions.length];
 		Arrays.fill(enabledTransitions, false);

--- a/test/unit_tests/PNMLreaderTestSuite.java
+++ b/test/unit_tests/PNMLreaderTestSuite.java
@@ -107,18 +107,27 @@ public class PNMLreaderTestSuite {
 			
 			final int expectedArcsAmount = 12;
 			HashMap<String, Arc> expectedArcs = new HashMap<String, Arc>();
-			expectedArcs.put("e-3DC6-6BDC2-11", new Arc("e-3DC6-6BDC2-11", "p-3DC6-6BDB5-6", "t-3DC6-6BDBA-8", 1));
-			expectedArcs.put("e-3DC6-6BDC3-12", new Arc("e-3DC6-6BDC3-12", "p-3DC6-6BDAF-3", "t-3DC6-6BDBD-9", 1));
-			expectedArcs.put("e-3DC6-6BDC4-13", new Arc("e-3DC6-6BDC4-13", "t-3DC6-6BDB6-7", "p-3DC6-6BDAF-3", 1));
-			expectedArcs.put("e-3DC6-6BDC4-14", new Arc("e-3DC6-6BDC4-14", "p-3DC6-6BDA9-2", "t-3DC6-6BDB6-7", 1));
-			expectedArcs.put("e-3DC6-6BDC6-15", new Arc("e-3DC6-6BDC6-15", "t-3DC6-6BDBF-10", "p-3DC6-6BDB5-6", 1));
-			expectedArcs.put("e-3DC6-6BDC7-16", new Arc("e-3DC6-6BDC7-16", "t-3DC6-6BDBF-10", "p-3DC6-6BDB0-4", 1));
-			expectedArcs.put("e-3DC6-6BDD7-17", new Arc("e-3DC6-6BDD7-17", "p-3DC6-6BDB2-5", "t-3DC6-6BDBF-10", 1));
-			expectedArcs.put("e-3DC6-6BDD8-18", new Arc("e-3DC6-6BDD8-18", "t-3DC6-6BDBA-8", "p-3DC6-6BDB2-5", 1));
-			expectedArcs.put("e-3DC6-6BDD8-19", new Arc("e-3DC6-6BDD8-19", "p-3DC6-6BDB0-4", "t-3DC6-6BDBA-8", 1));
-			expectedArcs.put("e-3DC6-6BDD9-20", new Arc("e-3DC6-6BDD9-20", "t-3DC6-6BDBD-9", "p-3DC6-6BDB5-6", 5));
-			expectedArcs.put("e-3DC6-6BDDA-21", new Arc("e-3DC6-6BDDA-21", "p-3DC6-6BDB5-6", "t-3DC6-6BDB6-7", 5));
-			expectedArcs.put("e-3DC6-6BDDC-22", new Arc("e-3DC6-6BDDC-22", "t-3DC6-6BDBD-9", "p-3DC6-6BDA9-2", 1));
+			Place p0 = new Place("p-3DC6-6BDA9-2", 1, 0, "p0");
+			Place p1 = new Place("p-3DC6-6BDAF-3", 0, 1, "p1");
+			Place p2 = new Place("p-3DC6-6BDB0-4", 5, 2, "p2");
+			Place p3 = new Place("p-3DC6-6BDB2-5", 0, 3, "p3");
+			Place p4 = new Place("p-3DC6-6BDB5-6", 5, 4, "p4");
+			Transition t0 = new Transition("t-3DC6-6BDB6-7", new Label(false, false), 0, "t0");
+			Transition t1 = new Transition("t-3DC6-6BDBA-8", new Label(false, false), 1, "t1");
+			Transition t2 = new Transition("t-3DC6-6BDBD-9", new Label(true, true), 2, "t2");
+			Transition t3 = new Transition("t-3DC6-6BDBF-10", new Label(true, true), 3, "t3");
+			expectedArcs.put("e-3DC6-6BDC2-11", new Arc("e-3DC6-6BDC2-11", p4, t1, 1));
+			expectedArcs.put("e-3DC6-6BDC3-12", new Arc("e-3DC6-6BDC3-12", p1, t2, 1));
+			expectedArcs.put("e-3DC6-6BDC4-13", new Arc("e-3DC6-6BDC4-13", t0, p1, 1));
+			expectedArcs.put("e-3DC6-6BDC4-14", new Arc("e-3DC6-6BDC4-14", p0, t0, 1));
+			expectedArcs.put("e-3DC6-6BDC6-15", new Arc("e-3DC6-6BDC6-15", t3, p4, 1));
+			expectedArcs.put("e-3DC6-6BDC7-16", new Arc("e-3DC6-6BDC7-16", t3, p2, 1));
+			expectedArcs.put("e-3DC6-6BDD7-17", new Arc("e-3DC6-6BDD7-17", p3, t3, 1));
+			expectedArcs.put("e-3DC6-6BDD8-18", new Arc("e-3DC6-6BDD8-18", t1, p3, 1));
+			expectedArcs.put("e-3DC6-6BDD8-19", new Arc("e-3DC6-6BDD8-19", p2, t1, 1));
+			expectedArcs.put("e-3DC6-6BDD9-20", new Arc("e-3DC6-6BDD9-20", t2, p4, 5));
+			expectedArcs.put("e-3DC6-6BDDA-21", new Arc("e-3DC6-6BDDA-21", p4, t0, 5));
+			expectedArcs.put("e-3DC6-6BDDC-22", new Arc("e-3DC6-6BDDC-22", t2, p0, 1));
 			
 			Arc[] obtainedArcs = petriObjects.getValue2();
 			
@@ -127,8 +136,8 @@ public class PNMLreaderTestSuite {
 			for(Arc arc : obtainedArcs){
 				try{
 					Arc expectedArc = expectedArcs.get(arc.getId());
-					assertEquals(expectedArc.getId_source(), arc.getId_source());
-					assertEquals(expectedArc.getId_target(), arc.getId_target());
+					assertEquals(expectedArc.getSource().getId(), arc.getSource().getId());
+					assertEquals(expectedArc.getTarget().getId(), arc.getTarget().getId());
 					assertEquals(expectedArc.getWeight(), arc.getWeight());
 				} catch (IndexOutOfBoundsException ex){
 					fail("An unexpected arc was recieved");
@@ -266,7 +275,7 @@ public class PNMLreaderTestSuite {
 			
 			// get all matching arcs filtering the array as a stream by source id and target id. This should be just one
 			Arc[] matchingArcs = Arrays.stream(petriObjects.getValue2())
-					.filter((Arc a) -> a.getId_source().equals(p2.getId()) &&  a.getId_target().equals(t2.getId()))
+					.filter((Arc a) -> a.getSource().getId().equals(p2.getId()) &&  a.getTarget().getId().equals(t2.getId()))
 					.toArray((size) -> new Arc[size]);
 			
 			assertEquals(1, matchingArcs.length);

--- a/test/unit_tests/PetriNetFactoryTestSuite.java
+++ b/test/unit_tests/PetriNetFactoryTestSuite.java
@@ -3,6 +3,8 @@ package unit_tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.io.FileNotFoundException;
+
 import org.javatuples.Triplet;
 import org.junit.After;
 import org.junit.Assert;
@@ -185,5 +187,44 @@ public class PetriNetFactoryTestSuite {
 			fail("No exception should've been thrown");
 		}
 	}
-
+	
+	/**
+	 * <li> Given t1 is fed by p0 with an inhibitor arc </li>
+	 * <li> And t1 is fed by p1 with a reset arc </li>
+	 * <li> When the Petri Net Factory tries to create petri net</li>
+	 * <li> Then it throws an error</li>
+	 */
+	@Test
+	public void petriNetFactoryShouldThrowErrorWhenTransitionWithInputResetArcHasInhibitorInput() {
+		try{
+			String PNMLFile = "test/unit_tests/testResources/petriWithResetAndOtherWrongArcs01.pnml";
+			PNMLreader reader = new PNMLreader(PNMLFile);
+			new PetriNetFactory(reader).makePetriNet(petriNetType.PT);
+			fail("Error should've be thrown before this point");
+		} catch(Error e){
+			assertEquals("CannotCreatePetriNetError", e.getClass().getSimpleName());
+		} catch (FileNotFoundException | SecurityException | NullPointerException e) {
+			fail("Incorrect exception recieved: " + e.getClass().getSimpleName());
+		}
+	}
+	
+	/**
+	 * <li> Given t0 is fed by p0 with a reset arc </li>
+	 * <li> And t1 is fed by p1 with a normal arc </li>
+	 * <li> When the Petri Net Factory tries to create petri net</li>
+	 * <li> Then it throws an error</li>
+	 */
+	@Test
+	public void petriNetFactoryShouldThrowErrorWhenTransitionWithInputResetArcHasNormalInput() {
+		try{
+			String PNMLFile = "test/unit_tests/testResources/petriWithResetAndOtherWrongArcs02.pnml";
+			PNMLreader reader = new PNMLreader(PNMLFile);
+			new PetriNetFactory(reader).makePetriNet(petriNetType.PT);
+			fail("Error should've be thrown before this point");
+		} catch(Error e){
+			assertEquals("CannotCreatePetriNetError", e.getClass().getSimpleName());
+		} catch (FileNotFoundException | SecurityException | NullPointerException e) {
+			fail("Incorrect exception recieved: " + e.getClass().getSimpleName());
+		}
+	}
 }

--- a/test/unit_tests/PetriNetFactoryTestSuite.java
+++ b/test/unit_tests/PetriNetFactoryTestSuite.java
@@ -32,22 +32,21 @@ public class PetriNetFactoryTestSuite {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		final Place[] mockPlaces = {
-			new Place("p0", 2, 0, "p0"),
-			new Place("p1", 1, 1, "p1"),
-			new Place("p2", 0, 2, "p2")
-		};
-		final Transition[] mockTransitions = {
-			new Transition("t0", new Label(false, false), 0, new TimeSpan(0,0), "t0"),
-			new Transition("t1", new Label(false, false), 1, new TimeSpan(0,0), "t1")
-		};
+		Place p0 = new Place("p0", 2, 0, "p0");
+		Place p1 = new Place("p1", 1, 1, "p1");
+		Place p2 = new Place("p2", 0, 2, "p2");
+		final Place[] mockPlaces = { p0, p1, p2 };
+		
+		Transition t0 = new Transition("t0", new Label(false, false), 0, new TimeSpan(0,0), "t0");
+		Transition t1 = new Transition("t1", new Label(false, false), 1, new TimeSpan(0,0), "t1");
+		final Transition[] mockTransitions = { t0, t1 };
 		final Arc[] mockArcs = {
-			new Arc("a0", "p0", "t0", 2),
-			new Arc("a1", "p1", "t0", 1),
-			new Arc("a2", "t0", "p2", 1),
-			new Arc("a3", "p2", "t1", 1),
-			new Arc("a4", "t1", "p0", 2),
-			new Arc("a5", "t1", "p1", 1)
+			new Arc("a0", p0, t0, 2),
+			new Arc("a1", p1, t0, 1),
+			new Arc("a2", t0, p2, 1),
+			new Arc("a3", p2, t1, 1),
+			new Arc("a4", t1, p0, 2),
+			new Arc("a5", t1, p1, 1)
 		};
 		mockPetriObjects = new Triplet<Place[], Transition[], Arc[]>(mockPlaces, mockTransitions, mockArcs);
 		

--- a/test/unit_tests/PetriNetTestSuite.java
+++ b/test/unit_tests/PetriNetTestSuite.java
@@ -23,6 +23,7 @@ public class PetriNetTestSuite {
 	private static final String PETRI_WITH_INHIBITOR_01 = TEST_PETRI_FOLDER + "petriWithInhibitor01.pnml";
 	private static final String PETRI_WITH_RESET_01 = TEST_PETRI_FOLDER + "petriWithReset01.pnml";
 	private static final String PETRI_WITH_RESET_02 = TEST_PETRI_FOLDER + "petriWithReset02.pnml";
+	private static final String PETRI_WITH_RESET_03 = TEST_PETRI_FOLDER + "petriWithReset03.pnml";
 	
 	private static PetriNetFactory factory;
 	private PetriNet petriNet;
@@ -492,6 +493,42 @@ public class PetriNetTestSuite {
 			
 		} catch (Exception e){
 			Assert.fail("Could not open or parse file " + PETRI_WITH_RESET_02);
+		}
+	}
+	
+	/**
+	 * <li> Given p0 has four tokens </li>
+	 * <li> And p1, p2 and p3 have no tokens </li>
+	 * <li> And t0 is fed by p0 with a reset arc </li>
+	 * <li> and t3 feeds p1, p2 and p3 with normal arcs </li>
+	 * <li> And t3 is enabled </li>
+	 * <li> When I try to fire t3 </li>
+	 * <li> Then t3 is fired successfully </li>
+	 * <li> And all tokens (four) are taken from p0 </li>
+	 * <li> And a token is put into p1, p2 and p3</li>
+	 */
+	@Test
+	public void FireTransitionWithResetArcAndOtherOutputArcsShouldFireSuccesfully(){
+		try{
+			readFileAndMakePetriNet(PETRI_WITH_RESET_03);
+			
+			Transition t0 = petriNet.getTransitions()[0];
+			
+			Integer[] expectedMarking = {Integer.valueOf(4) , Integer.valueOf(0), Integer.valueOf(0), Integer.valueOf(0)};
+			Assert.assertArrayEquals(expectedMarking, petriNet.getCurrentMarking());
+			
+			Assert.assertTrue(petriNet.isEnabled(t0));
+			
+			Assert.assertTrue(petriNet.fire(t0));
+			
+			expectedMarking[0] = 0;
+			expectedMarking[1] = 1;
+			expectedMarking[2] = 1;
+			expectedMarking[3] = 1;
+			Assert.assertArrayEquals(expectedMarking, petriNet.getCurrentMarking());
+			
+		} catch (Exception e){
+			Assert.fail("Could not open or parse file " + PETRI_WITH_RESET_03);
 		}
 	}
 }

--- a/test/unit_tests/testResources/petriWithReset03.ndr
+++ b/test/unit_tests/testResources/petriWithReset03.ndr
@@ -1,0 +1,12 @@
+p 95.0 50.0 p0 4 n
+t 95.0 145.0 t0 0 w n
+p 30.0 240.0 p1 0 n
+p 95.0 240.0 p2 0 n
+p 160.0 240.0 p3 0 n
+e t0 p3 1 n
+e t0 p2 1 n
+e t0 p1 1 n
+e p0 t0 !1 n
+h petriWithReset03
+
+

--- a/test/unit_tests/testResources/petriWithReset03.pnml
+++ b/test/unit_tests/testResources/petriWithReset03.pnml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+ <net id="n-1CEC-A40A9-0" type ="http://www.laas.fr/tina/tpn">
+  <name>
+   <text>petriWithReset03</text>
+  </name>
+ <page id="g-1CEC-A40B7-1">
+  <place id="p-1CEC-A40BA-2">
+  <name>
+   <text>p0</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>4</text>
+   </initialMarking>
+   <graphics>
+    <position x="95" y="50"/>
+   </graphics>
+  </place>
+  <place id="p-1CEC-A40C8-3">
+  <name>
+   <text>p1</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="30" y="240"/>
+   </graphics>
+  </place>
+  <place id="p-1CEC-A40CC-4">
+  <name>
+   <text>p2</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="95" y="240"/>
+   </graphics>
+  </place>
+  <place id="p-1CEC-A40CE-5">
+  <name>
+   <text>p3</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="160" y="240"/>
+   </graphics>
+  </place>
+  <transition id="t-1CEC-A40D1-6">
+  <name>
+   <text>t0</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="95" y="145"/>
+   </graphics>
+  </transition>
+  <arc id="e-1CEC-A40D5-7" source="t-1CEC-A40D1-6" target="p-1CEC-A40CE-5">
+  </arc>
+  <arc id="e-1CEC-A40D8-8" source="t-1CEC-A40D1-6" target="p-1CEC-A40CC-4">
+  </arc>
+  <arc id="e-1CEC-A40D9-9" source="t-1CEC-A40D1-6" target="p-1CEC-A40C8-3">
+  </arc>
+  <arc id="e-1CEC-A40DB-10" source="p-1CEC-A40BA-2" target="t-1CEC-A40D1-6">
+   <type value="reset"/>
+  </arc>
+ </page>
+ </net>
+</pnml>

--- a/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs01.ndr
+++ b/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs01.ndr
@@ -1,0 +1,13 @@
+t 30.0 150.0 t0 0 w n
+p 30.0 235.0 p1 4 n
+t 30.0 330.0 t1 0 w n
+p 30.0 430.0 p2 0 n
+p 30.0 50.0 p0 1 n
+e p0 0.8701044694 91.96738552 t1 0.1121926408 87.96590248 ?-1 n
+e p0 t0 1 n
+e t0 p1 1 n
+e t1 p2 1 n
+e p1 t1 !1 n
+h petriWithResetAndOtherWrongArcs01
+
+

--- a/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs01.pnml
+++ b/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs01.pnml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+ <net id="n-1320-387E8-0" type ="http://www.laas.fr/tina/tpn">
+  <name>
+   <text>petriWithResetAndOtherWrongArcs01</text>
+  </name>
+ <page id="g-1320-387F3-1">
+  <place id="p-1320-387F6-2">
+  <name>
+   <text>p0</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>1</text>
+   </initialMarking>
+   <graphics>
+    <position x="30" y="50"/>
+   </graphics>
+  </place>
+  <place id="p-1320-38803-3">
+  <name>
+   <text>p1</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>4</text>
+   </initialMarking>
+   <graphics>
+    <position x="30" y="235"/>
+   </graphics>
+  </place>
+  <place id="p-1320-38806-4">
+  <name>
+   <text>p2</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="30" y="430"/>
+   </graphics>
+  </place>
+  <transition id="t-1320-38809-5">
+  <name>
+   <text>t0</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="30" y="150"/>
+   </graphics>
+  </transition>
+  <transition id="t-1320-3880C-6">
+  <name>
+   <text>t1</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="30" y="330"/>
+   </graphics>
+  </transition>
+  <arc id="e-1320-3880F-7" source="p-1320-387F6-2" target="t-1320-3880C-6">
+   <type value="inhibitor"/>
+   <graphics>
+    <position x="80" y="104" />
+    <position x="84" y="284" />
+   </graphics>  </arc>
+  <arc id="e-1320-38818-8" source="p-1320-387F6-2" target="t-1320-38809-5">
+  </arc>
+  <arc id="e-1320-38819-9" source="t-1320-38809-5" target="p-1320-38803-3">
+  </arc>
+  <arc id="e-1320-3881A-10" source="t-1320-3880C-6" target="p-1320-38806-4">
+  </arc>
+  <arc id="e-1320-3881B-11" source="p-1320-38803-3" target="t-1320-3880C-6">
+   <type value="reset"/>
+  </arc>
+ </page>
+ </net>
+</pnml>

--- a/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs02.ndr
+++ b/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs02.ndr
@@ -1,0 +1,14 @@
+p 115.0 50.0 p0 4 n
+t 115.0 145.0 t0 0 w n
+p 250.0 50.0 p1 1 n
+p 30.0 245.0 p2 0 n
+p 115.0 245.0 p3 0 n
+p 195.0 245.0 p4 0 n
+e t0 p4 1 n
+e t0 p3 1 n
+e p1 t0 1 n
+e p0 t0 !1 n
+e t0 p2 1 n
+h petriWithResetAndOtherWrongArcs02
+
+

--- a/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs02.pnml
+++ b/test/unit_tests/testResources/petriWithResetAndOtherWrongArcs02.pnml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+ <net id="n-18CC-F3CD6-0" type ="http://www.laas.fr/tina/tpn">
+  <name>
+   <text>petriWithResetAndOtherWrongArcs02</text>
+  </name>
+ <page id="g-18CC-F3CED-1">
+  <place id="p-18CC-F3CF0-2">
+  <name>
+   <text>p0</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>4</text>
+   </initialMarking>
+   <graphics>
+    <position x="115" y="50"/>
+   </graphics>
+  </place>
+  <place id="p-18CC-F3D05-3">
+  <name>
+   <text>p1</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>1</text>
+   </initialMarking>
+   <graphics>
+    <position x="250" y="50"/>
+   </graphics>
+  </place>
+  <place id="p-18CC-F3D09-4">
+  <name>
+   <text>p2</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="30" y="245"/>
+   </graphics>
+  </place>
+  <place id="p-18CC-F3D0E-5">
+  <name>
+   <text>p3</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="115" y="245"/>
+   </graphics>
+  </place>
+  <place id="p-18CC-F3D19-6">
+  <name>
+   <text>p4</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="195" y="245"/>
+   </graphics>
+  </place>
+  <transition id="t-18CC-F3D1C-7">
+  <name>
+   <text>t0</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="115" y="145"/>
+   </graphics>
+  </transition>
+  <arc id="e-18CC-F3D23-8" source="t-18CC-F3D1C-7" target="p-18CC-F3D19-6">
+  </arc>
+  <arc id="e-18CC-F3D27-9" source="t-18CC-F3D1C-7" target="p-18CC-F3D0E-5">
+  </arc>
+  <arc id="e-18CC-F3D28-10" source="p-18CC-F3D05-3" target="t-18CC-F3D1C-7">
+  </arc>
+  <arc id="e-18CC-F3D2A-11" source="p-18CC-F3CF0-2" target="t-18CC-F3D1C-7">
+   <type value="reset"/>
+  </arc>
+  <arc id="e-18CC-F3D2D-12" source="t-18CC-F3D1C-7" target="p-18CC-F3D09-4">
+  </arc>
+ </page>
+ </net>
+</pnml>


### PR DESCRIPTION
Simplification added to rdpObjects2Matrices. Since now places and transitions are ordered and know their indexes in the matrices, building the matrices can be simplified.
Besides, illegal petriNet topologies check responsibility was moved to PNMLreader where it should've been.

TODO: Add tests for illegal topologies

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airabinovich/java_petri_engine/15)

<!-- Reviewable:end -->
