### PR TITLE
Bug #22 fixed, and tests were added

### DIFF
--- a/src/Petri/NotInitializedTimedPetriNetException.java
+++ b/src/Petri/NotInitializedTimedPetriNetException.java
@@ -1,0 +1,27 @@
+package Petri;
+
+public class NotInitializedTimedPetriNetException extends Exception {
+	
+	private static final long serialVersionUID = 5988729711337034401L;
+
+	public NotInitializedTimedPetriNetException(){
+		super("The Timed Petri Net is not initialized");
+	}
+	
+	public NotInitializedTimedPetriNetException(String message){
+		super(message);
+	}
+	
+	public NotInitializedTimedPetriNetException(Throwable cause) {
+		super(cause);
+	}
+
+	public NotInitializedTimedPetriNetException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
+	public NotInitializedTimedPetriNetException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/Petri/TimeSpan.java
+++ b/src/Petri/TimeSpan.java
@@ -18,6 +18,7 @@ public class TimeSpan {
 	public TimeSpan(long timeB, long timeE){
 		this.timeBegin = timeB;
 		this.timeEnd = timeE;
+		this.enableTime = -1;
 	}
 	
 	/**
@@ -47,7 +48,10 @@ public class TimeSpan {
 	 * @param time timestamp in miliseconds to figure out whether it's inside the span
 	 * @return true if time is inside the span
 	 */
-	public boolean inTimeSpan(long time){
+	public boolean inTimeSpan(long time) throws NotInitializedTimedPetriNetException{
+		if(enableTime == -1){
+			throw new NotInitializedTimedPetriNetException("The Petri Net times are not initialized");
+		}
 		if(time >= enableTime + timeBegin){
 			if(timeEnd == Long.MAX_VALUE){
 				return true;
@@ -63,7 +67,10 @@ public class TimeSpan {
 	 * @param time timestamp in miliseconds to figure out whether it's before the span
 	 * @return true if time is befire the span
 	 */
-	public boolean isBeforeTimeSpan(long time){
+	public boolean isBeforeTimeSpan(long time) throws NotInitializedTimedPetriNetException{
+		if(enableTime == -1){
+			throw new NotInitializedTimedPetriNetException("The Petri Net times are not initialized");
+		}
 		return time < enableTime + timeBegin;
 	}
 	

--- a/src/Petri/TimeSpan.java
+++ b/src/Petri/TimeSpan.java
@@ -46,11 +46,12 @@ public class TimeSpan {
 	
 	/**
 	 * @param time timestamp in miliseconds to figure out whether it's inside the span
+	 * @throws NotInitializedTimedPetriNetException if the time is not initialized
 	 * @return true if time is inside the span
 	 */
 	public boolean inTimeSpan(long time) throws NotInitializedTimedPetriNetException{
 		if(enableTime == -1){
-			throw new NotInitializedTimedPetriNetException("The Petri Net times are not initialized");
+			throw new NotInitializedTimedPetriNetException();
 		}
 		if(time >= enableTime + timeBegin){
 			if(timeEnd == Long.MAX_VALUE){
@@ -65,11 +66,12 @@ public class TimeSpan {
 	
 	/**
 	 * @param time timestamp in miliseconds to figure out whether it's before the span
+	 * @throws NotInitializedTimedPetriNetException if the time is not initialized
 	 * @return true if time is befire the span
 	 */
 	public boolean isBeforeTimeSpan(long time) throws NotInitializedTimedPetriNetException{
 		if(enableTime == -1){
-			throw new NotInitializedTimedPetriNetException("The Petri Net times are not initialized");
+			throw new NotInitializedTimedPetriNetException();
 		}
 		return time < enableTime + timeBegin;
 	}

--- a/src/Petri/TimedPetriNet.java
+++ b/src/Petri/TimedPetriNet.java
@@ -12,6 +12,7 @@ public class TimedPetriNet extends PetriNet{
 	 * the enabled transitions
 	 * The enabled transitions are not calculated at initialization time, so
 	 * before firing the first transition, they must be calculated @see {@link TimedPetriNet#startTimes()}
+	 * Other way to start times is firing a non timed transition before a timed transition
 	 * @see PetriNet#PetriNet(Place[], Transition[], Arc[], Integer[], Integer[][], Integer[][], Integer[][])
 	 */
 	public TimedPetriNet(Place[] _places, Transition[] _transitions, Arc[] _arcs, Integer[] _initialMarking,

--- a/src/Petri/TimedPetriNet.java
+++ b/src/Petri/TimedPetriNet.java
@@ -4,14 +4,14 @@ import java.util.Arrays;
 
 public class TimedPetriNet extends PetriNet{
 
-	protected boolean timesStarted;
+	protected boolean timedPetriNetInitialized;
 	protected boolean[] enabledTransitions;
 	
 	/**
 	 * extends the abstract class PetriNet, and also has a boolean array containing
 	 * the enabled transitions
 	 * The enabled transitions are not calculated at initialization time, so
-	 * before fire the first transition, there must calculate them @see {@link TimedPetriNet#startTimes()}
+	 * before firing the first transition, they must be calculated @see {@link TimedPetriNet#startTimes()}
 	 * @see PetriNet#PetriNet(Place[], Transition[], Arc[], Integer[], Integer[][], Integer[][], Integer[][])
 	 */
 	public TimedPetriNet(Place[] _places, Transition[] _transitions, Arc[] _arcs, Integer[] _initialMarking,
@@ -19,21 +19,22 @@ public class TimedPetriNet extends PetriNet{
 		super(_places, _transitions, _arcs, _initialMarking, _preI, _posI, _I, _inhibition, _resetMatrix);
 		enabledTransitions = new boolean[_transitions.length];
 		Arrays.fill(enabledTransitions, false);
-		this.timesStarted = false;
+		this.timedPetriNetInitialized = false;
 	}
 
 	/**
-	 * Computes the enabled transitions for first time
-	 * Uses the method computeEnabledTransitions and set the times
+	 * Computes the enabled transitions for first time and
+	 * set the times to timed transitions
 	 * @see TimedPetriNet#computeEnabledTransitions() 
 	 */
 	public void startTimes(){
 		this.enabledTransitions = computeEnabledTransitions();
-		this.timesStarted = true;
+		this.timedPetriNetInitialized = true;
 	}
 	
 	/**
 	 * Fires the transition specified by transitionIndex and updates the enabled transitions with their timestamps
+	 * If net is not initialized when calling this method, NotInitializedTimedPetriNetException will be thrown
 	 * @param transitionIndex The index of the transition to be fired
 	 * @return True if the fire was successful
 	 * @throws NotInitializedTimedPetriNetException if the times are not initialized
@@ -87,8 +88,8 @@ public class TimedPetriNet extends PetriNet{
 		return _enabledTransitions;
 	}
 	
-	public boolean isTimesStarted() {
-		return this.timesStarted;
+	public boolean isTimedPetriNetInitialized() {
+		return timedPetriNetInitialized;
 	}
 
 }

--- a/src/Petri/TimedPetriNet.java
+++ b/src/Petri/TimedPetriNet.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 public class TimedPetriNet extends PetriNet{
 
+	protected boolean timesStarted;
 	protected boolean[] enabledTransitions;
 	
 	/**
@@ -18,25 +19,28 @@ public class TimedPetriNet extends PetriNet{
 		super(_places, _transitions, _arcs, _initialMarking, _preI, _posI, _I, _inhibition, _resetMatrix);
 		enabledTransitions = new boolean[_transitions.length];
 		Arrays.fill(enabledTransitions, false);
+		this.timesStarted = false;
 	}
 
 	/**
-	 * Computes the enabled transitions
+	 * Computes the enabled transitions for first time
 	 * Uses the method computeEnabledTransitions and set the times
-	 * @see {@link TimedPetriNet#computeEnabledTransitions()} 
+	 * @see TimedPetriNet#computeEnabledTransitions() 
 	 */
 	public void startTimes(){
 		this.enabledTransitions = computeEnabledTransitions();
+		this.timesStarted = true;
 	}
 	
 	/**
 	 * Fires the transition specified by transitionIndex and updates the enabled transitions with their timestamps
 	 * @param transitionIndex The index of the transition to be fired
 	 * @return True if the fire was successful
-	 * @throws IllegalArgumentException If the index is negative or greater than the last transition index.
+	 * @throws NotInitializedTimedPetriNetException if the times are not initialized
+	 * @see TimedPetriNet#startTimes()
 	 * @see PetriNet#fire(int)
 	 */
-	public boolean fire(int transitionIndex) throws IllegalArgumentException{
+	public boolean fire(int transitionIndex){
 		boolean wasFired = super.fire(transitionIndex);
 		//Compute new enabled transitions and set new timestamp 
 		this.enabledTransitions = computeEnabledTransitions();
@@ -48,6 +52,7 @@ public class TimedPetriNet extends PetriNet{
 	 * @param t The transition to be fired
 	 * @return True if the fire was successful
 	 * @throws IllegalArgumentException If t is null or if it doesn't match any transition index.
+	 * @see TimedPetriNet#startTimes()
 	 * @see PetriNet#fire(Transition)
 	 */
 	public boolean fire(final Transition t) throws IllegalArgumentException{
@@ -81,4 +86,9 @@ public class TimedPetriNet extends PetriNet{
 		}
 		return _enabledTransitions;
 	}
+	
+	public boolean isTimesStarted() {
+		return this.timesStarted;
+	}
+
 }

--- a/src/Petri/TimedPetriNet.java
+++ b/src/Petri/TimedPetriNet.java
@@ -8,7 +8,9 @@ public class TimedPetriNet extends PetriNet{
 	
 	/**
 	 * extends the abstract class PetriNet, and also has a boolean array containing
-	 * the enabled transitions 
+	 * the enabled transitions
+	 * The enabled transitions are not calculated at initialization time, so
+	 * before fire the first transition, there must calculate them @see {@link TimedPetriNet#startTimes()}
 	 * @see PetriNet#PetriNet(Place[], Transition[], Arc[], Integer[], Integer[][], Integer[][], Integer[][])
 	 */
 	public TimedPetriNet(Place[] _places, Transition[] _transitions, Arc[] _arcs, Integer[] _initialMarking,
@@ -16,9 +18,25 @@ public class TimedPetriNet extends PetriNet{
 		super(_places, _transitions, _arcs, _initialMarking, _preI, _posI, _I, _inhibition, _resetMatrix);
 		enabledTransitions = new boolean[_transitions.length];
 		Arrays.fill(enabledTransitions, false);
-		this.enabledTransitions = computeEnabledTransitions();
 	}
 
+	/**
+	 * Computes the enabled transitions
+	 * Uses the method computeEnabledTransitions and set the times in order to
+	 * avoid the time race condition related to initialization times
+	 * @see {@link TimedPetriNet#computeEnabledTransitions()} 
+	 */
+	public void startTimes(){
+		long time = System.currentTimeMillis();
+		for(Transition t : transitions){
+			boolean transitionEnabled = isEnabled(t);
+			this.enabledTransitions[t.getIndex()] = transitionEnabled;
+			if (t.getTimeSpan() != null && isEnabled(t)){
+				t.getTimeSpan().setEnableTime(time);
+			}
+		}
+	}
+	
 	/**
 	 * Fires the transition specified by transitionIndex and updates the enabled transitions with their timestamps
 	 * @param transitionIndex The index of the transition to be fired
@@ -51,6 +69,11 @@ public class TimedPetriNet extends PetriNet{
 		return this.enabledTransitions;
 	}
 	
+	/**
+	 * Computes the enabled transitions, setting the enable times if it is necessary
+	 * If a transition was enabled, its timespan is not updated
+	 * @return True if the fire was successful
+	 */
 	protected boolean[] computeEnabledTransitions(){
 		boolean[] _enabledTransitions = new boolean[transitions.length];
 		for(Transition t : transitions){
@@ -62,7 +85,7 @@ public class TimedPetriNet extends PetriNet{
 				if (transitionEnabled && !enabledTransitions[transitionIndex]){
 					t.getTimeSpan().setEnableTime(System.currentTimeMillis());
 				}
-			}			
+			}
 		}
 		return _enabledTransitions;
 	}

--- a/src/Petri/TimedPetriNet.java
+++ b/src/Petri/TimedPetriNet.java
@@ -22,19 +22,11 @@ public class TimedPetriNet extends PetriNet{
 
 	/**
 	 * Computes the enabled transitions
-	 * Uses the method computeEnabledTransitions and set the times in order to
-	 * avoid the time race condition related to initialization times
+	 * Uses the method computeEnabledTransitions and set the times
 	 * @see {@link TimedPetriNet#computeEnabledTransitions()} 
 	 */
 	public void startTimes(){
-		long time = System.currentTimeMillis();
-		for(Transition t : transitions){
-			boolean transitionEnabled = isEnabled(t);
-			this.enabledTransitions[t.getIndex()] = transitionEnabled;
-			if (t.getTimeSpan() != null && isEnabled(t)){
-				t.getTimeSpan().setEnableTime(time);
-			}
-		}
+		this.enabledTransitions = computeEnabledTransitions();
 	}
 	
 	/**
@@ -70,9 +62,9 @@ public class TimedPetriNet extends PetriNet{
 	}
 	
 	/**
-	 * Computes the enabled transitions, setting the enable times if it is necessary
-	 * If a transition was enabled, its timespan is not updated
-	 * @return True if the fire was successful
+	 * Computes the enabled transitions, setting the enable times for new enabled transitions only
+	 * If a transition was already enabled, its timespan is not updated
+	 * @return the boolean array with enabled transitions
 	 */
 	protected boolean[] computeEnabledTransitions(){
 		boolean[] _enabledTransitions = new boolean[transitions.length];

--- a/src/monitor_petri/MonitorManager.java
+++ b/src/monitor_petri/MonitorManager.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Semaphore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import Petri.NotInitializedTimedPetriNetException;
 import Petri.PetriNet;
 import Petri.TimeSpan;
 import Petri.Transition;
@@ -78,10 +79,11 @@ public class MonitorManager {
 	 * </ul>
 	 * For timed transitions, the calling thread sleeps until the transition reaches its time span, only then fires it.
 	 * @param transitionToFire The transition to fire
+	 * @throws NotInitializedTimedPetriNetException 
 	 * @throws IllegalTransitionFiringError when an request to fire an automatic transition arrives
 	 * @see PetriNet#fire(Transition, boolean)
 	 */
-	public void fireTransition(final Transition transitionToFire){
+	public void fireTransition(final Transition transitionToFire) throws IllegalTransitionFiringError, NotInitializedTimedPetriNetException{
 		fireTransition(transitionToFire, false);
 	}
 
@@ -104,9 +106,10 @@ public class MonitorManager {
 	 * @param transitionToFire The transition to fire
 	 * @param perenialFire True indicates a perennial fire
 	 * @throws IllegalTransitionFiringError when an request to fire an automatic transition arrives
+	 * @throws NotInitializedTimedPetriNetException 
 	 * @see PetriNet#fire(Transition, boolean)
 	 */
-	public void fireTransition(final Transition transitionToFire, boolean perennialFire) throws IllegalTransitionFiringError{
+	public void fireTransition(final Transition transitionToFire, boolean perennialFire) throws IllegalTransitionFiringError, NotInitializedTimedPetriNetException{
 		// An attempt to fire an automatic transition is a severe error and the application should stop automatically
 		if(transitionToFire.getLabel().isAutomatic()){
 			throw new IllegalTransitionFiringError("An automatic transition has tried to be fired manually");
@@ -129,8 +132,9 @@ public class MonitorManager {
 	 * @param transitionName The name of the transition to fire.
 	 * @throws IllegalArgumentException If no transition matches transitionName
 	 * @throws IllegalTransitionFiringError If transitionName matches an automatic transition
+	 * @throws NotInitializedTimedPetriNetException 
 	 */
-	public void fireTransition(final String transitionName) throws IllegalArgumentException, IllegalTransitionFiringError {
+	public void fireTransition(final String transitionName) throws IllegalArgumentException, IllegalTransitionFiringError, NotInitializedTimedPetriNetException {
 		Optional<Transition> filteredTransition = Arrays.stream(petri.getTransitions())
 				.filter((Transition t) -> t.getName().equals(transitionName))
 				// I can get only the first here because I made sure the name is unique in the parsing
@@ -203,8 +207,9 @@ public class MonitorManager {
 	 * @param newValue New value to set
 	 * @throws IndexOutOfBoundsException If the guard doesn't exist
 	 * @throws NullPointerException If guardName is empty
+	 * @throws NotInitializedTimedPetriNetException 
 	 */
-	public boolean setGuard(String guardName, boolean newValue) throws IndexOutOfBoundsException, NullPointerException{
+	public boolean setGuard(String guardName, boolean newValue) throws IndexOutOfBoundsException, NullPointerException, NotInitializedTimedPetriNetException{
 		if(guardName == null || guardName.isEmpty()){
 			throw new NullPointerException("Empty guard name not allowed");
 		}
@@ -295,8 +300,9 @@ public class MonitorManager {
 	 * @param perennialFire
 	 * @return permits to release to mutex {@link #inQueue}
 	 * @throws InterruptedException if the calling thread is interrupted
+	 * @throws NotInitializedTimedPetriNetException 
 	 */
-	private int internalFireTransition(Transition transitionToFire, boolean perennialFire) throws InterruptedException{
+	private int internalFireTransition(Transition transitionToFire, boolean perennialFire) throws InterruptedException, NotInitializedTimedPetriNetException{
 		int permitsToRelease = 1;
 		boolean keepFiring = true;
 		boolean insideTimeSpan = false;

--- a/src/monitor_petri/MonitorManager.java
+++ b/src/monitor_petri/MonitorManager.java
@@ -79,7 +79,7 @@ public class MonitorManager {
 	 * </ul>
 	 * For timed transitions, the calling thread sleeps until the transition reaches its time span, only then fires it.
 	 * @param transitionToFire The transition to fire
-	 * @throws NotInitializedTimedPetriNetException 
+	 * @throws NotInitializedTimedPetriNetException when firing a timed transition before initialize its time
 	 * @throws IllegalTransitionFiringError when an request to fire an automatic transition arrives
 	 * @see PetriNet#fire(Transition, boolean)
 	 */
@@ -106,7 +106,7 @@ public class MonitorManager {
 	 * @param transitionToFire The transition to fire
 	 * @param perenialFire True indicates a perennial fire
 	 * @throws IllegalTransitionFiringError when an request to fire an automatic transition arrives
-	 * @throws NotInitializedTimedPetriNetException 
+	 * @throws NotInitializedTimedPetriNetException when firing a timed transition before initialize its time
 	 * @see PetriNet#fire(Transition, boolean)
 	 */
 	public void fireTransition(final Transition transitionToFire, boolean perennialFire) throws IllegalTransitionFiringError, NotInitializedTimedPetriNetException{
@@ -132,7 +132,7 @@ public class MonitorManager {
 	 * @param transitionName The name of the transition to fire.
 	 * @throws IllegalArgumentException If no transition matches transitionName
 	 * @throws IllegalTransitionFiringError If transitionName matches an automatic transition
-	 * @throws NotInitializedTimedPetriNetException 
+	 * @throws NotInitializedTimedPetriNetException when firing a timed transition before initialize its time
 	 */
 	public void fireTransition(final String transitionName) throws IllegalArgumentException, IllegalTransitionFiringError, NotInitializedTimedPetriNetException {
 		Optional<Transition> filteredTransition = Arrays.stream(petri.getTransitions())
@@ -207,7 +207,7 @@ public class MonitorManager {
 	 * @param newValue New value to set
 	 * @throws IndexOutOfBoundsException If the guard doesn't exist
 	 * @throws NullPointerException If guardName is empty
-	 * @throws NotInitializedTimedPetriNetException 
+	 * @throws NotInitializedTimedPetriNetException when firing a timed transition before initialize its time
 	 */
 	public boolean setGuard(String guardName, boolean newValue) throws IndexOutOfBoundsException, NullPointerException, NotInitializedTimedPetriNetException{
 		if(guardName == null || guardName.isEmpty()){
@@ -300,7 +300,7 @@ public class MonitorManager {
 	 * @param perennialFire
 	 * @return permits to release to mutex {@link #inQueue}
 	 * @throws InterruptedException if the calling thread is interrupted
-	 * @throws NotInitializedTimedPetriNetException 
+	 * @throws NotInitializedTimedPetriNetException when firing a timed transition before initialize its time
 	 */
 	private int internalFireTransition(Transition transitionToFire, boolean perennialFire) throws InterruptedException, NotInitializedTimedPetriNetException{
 		int permitsToRelease = 1;

--- a/test/unit_tests/MonitorManagerTestSuite.java
+++ b/test/unit_tests/MonitorManagerTestSuite.java
@@ -14,12 +14,14 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import Petri.NotInitializedTimedPetriNetException;
 import Petri.PetriNet;
 import Petri.PetriNetFactory;
 import Petri.PetriNetFactory.petriNetType;
 import Petri.TimedPetriNet;
 import Petri.Transition;
 import monitor_petri.FirstInLinePolicy;
+import monitor_petri.IllegalTransitionFiringError;
 import monitor_petri.MonitorManager;
 import monitor_petri.TransitionsPolicy;
 import rx.Subscription;
@@ -72,7 +74,7 @@ public class MonitorManagerTestSuite {
 	}
 	
 	/**
-	 * Creates builder, petri and monitor from given PNML
+	 * Creates factory, petri and monitor from given PNML
 	 * @param PNML path to the PNML file
 	 */
 	private void setUpMonitor(String PNML){
@@ -103,7 +105,11 @@ public class MonitorManagerTestSuite {
 		TransitionEventObserver obs = new TransitionEventObserver();
 		monitor.subscribeToTransition(t1, obs);
 		
-		monitor.fireTransition(t0);
+		try {
+			monitor.fireTransition(t0);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exeption thrown in test execution");
+		}
 		
 		// this means that t1 emmited an event when it was fired
 		try {
@@ -146,7 +152,11 @@ public class MonitorManagerTestSuite {
 		final Transition t2 = petri.getTransitions()[2];
 		
 		Thread worker = new Thread(() -> {
-			monitor.fireTransition(t2);
+			try {
+				monitor.fireTransition(t2);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
 		});
 		worker.start();
 		
@@ -162,7 +172,11 @@ public class MonitorManagerTestSuite {
 		monitor.subscribeToTransition(t1, obs);
 		monitor.subscribeToTransition(t2, obs);
 		
-		monitor.fireTransition(t0);
+		try {
+			monitor.fireTransition(t0);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		try {
 			Thread.sleep(100);
@@ -223,6 +237,8 @@ public class MonitorManagerTestSuite {
 			Assert.fail("An IllegalTransitionFiringError should've been thrown before this point");
 		} catch (Error err){
 			Assert.assertEquals("IllegalTransitionFiringError", err.getClass().getSimpleName());
+		} catch (NotInitializedTimedPetriNetException e) {
+			Assert.fail("Exception thrown in test execution");
 		}
 	}
 	
@@ -247,7 +263,11 @@ public class MonitorManagerTestSuite {
 		
 		monitor.subscribeToTransition(t1, obs);
 		
-		monitor.fireTransition(t0);
+		try {
+			monitor.fireTransition(t0);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		ArrayList<String> events = obs.getEvents();
 		
@@ -335,7 +355,11 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(obs.getEvents().isEmpty());
 		
-		monitor.fireTransition(t0);
+		try {
+			monitor.fireTransition(t0);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		ArrayList<String> events = obs.getEvents();
 		
@@ -375,7 +399,11 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(obs.getEvents().isEmpty());
 		
-		monitor.fireTransition(t0);
+		try {
+			monitor.fireTransition(t0);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		ArrayList<String> events = obs.getEvents();
 		
@@ -391,7 +419,11 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(sub.isUnsubscribed());
 		
-		monitor.fireTransition(t0);
+		try {
+			monitor.fireTransition(t0);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		Assert.assertEquals(1, events.size());
 	}
@@ -424,13 +456,21 @@ public class MonitorManagerTestSuite {
 		TransitionEventObserver obs1 = new TransitionEventObserver();
 		monitor.subscribeToTransition(t1, obs1);
 		
-		monitor.fireTransition(t0);
+		try {
+			monitor.fireTransition(t0);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		expectedMarking[0] = false;
 		expectedMarking[1] = true;
 		Assert.assertArrayEquals(expectedMarking, petri.getEnabledTransitions());
 		
-		monitor.fireTransition(t1);
+		try {
+			monitor.fireTransition(t1);
+		} catch (IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		ArrayList<String> events0 = obs0.getEvents();
 		ArrayList<String> events1 = obs1.getEvents();
@@ -485,10 +525,22 @@ public class MonitorManagerTestSuite {
 		
 		petri.addGuard("test", true);
 		
-		Thread th0 = new Thread(() -> monitor.fireTransition(t0));
+		Thread th0 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t0);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th0.start();
 		
-		Thread th1 = new Thread(() -> monitor.fireTransition(t1));
+		Thread th1 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t1);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th1.start();
 		
 		try {
@@ -536,15 +588,29 @@ public class MonitorManagerTestSuite {
 		Transition t0 = petri.getTransitions()[0];
 		
 		// setting this guard here is just to enable t0
-		monitor.setGuard("test", true);
+		try {
+			monitor.setGuard("test", true);
+		} catch (IndexOutOfBoundsException | NullPointerException | NotInitializedTimedPetriNetException e2) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		Assert.assertTrue(petri.isEnabled(t0));
 		
-		monitor.setGuard("test", false);
+		try {
+			monitor.setGuard("test", false);
+		} catch (IndexOutOfBoundsException | NullPointerException | NotInitializedTimedPetriNetException e2) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		TransitionEventObserver obs = new TransitionEventObserver();
 		monitor.subscribeToTransition(t0, obs);
 		
-		Thread th0 = new Thread(() -> monitor.fireTransition(t0));
+		Thread th0 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t0);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th0.start();
 		
 		try {
@@ -556,7 +622,11 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(obs.getEvents().isEmpty());
 		
-		monitor.setGuard("test", true);
+		try {
+			monitor.setGuard("test", true);
+		} catch (IndexOutOfBoundsException | NullPointerException | NotInitializedTimedPetriNetException e2) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		try {
 			// let's give th0 some time to try to fire t0
@@ -602,14 +672,24 @@ public class MonitorManagerTestSuite {
 		Transition t2 = petri.getTransitions()[2];
 		
 		// setting this guard here is just to enable t0
-		monitor.setGuard("test", true);
+		try {
+			monitor.setGuard("test", true);
+		} catch (IndexOutOfBoundsException | NullPointerException | NotInitializedTimedPetriNetException e2) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		Assert.assertTrue(petri.isEnabled(t0));
 		
 		TransitionEventObserver obs = new TransitionEventObserver();
 		monitor.subscribeToTransition(t0, obs);
 		monitor.subscribeToTransition(t2, obs);
 		
-		Thread th0 = new Thread(() -> monitor.fireTransition(t0));
+		Thread th0 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t0);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th0.start();
 		
 		try {
@@ -629,7 +709,11 @@ public class MonitorManagerTestSuite {
 			Assert.fail("Event is not in JSON format");
 		}
 		
-		monitor.setGuard("test", false);
+		try {
+			monitor.setGuard("test", false);
+		} catch (IndexOutOfBoundsException | NullPointerException | NotInitializedTimedPetriNetException e2) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		try {
 			// let's give some time for t2 to get fired automatically
@@ -677,7 +761,15 @@ public class MonitorManagerTestSuite {
 		monitor.subscribeToTransition(t1, obs);
 		monitor.subscribeToTransition(t2, obs);
 		
-		new Thread(() -> monitor.fireTransition(t0)).start();
+		Thread worker = new Thread(() -> {
+			try {
+				monitor.fireTransition(t0);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
+		
+		worker.start();
 		
 		try{
 			Thread.sleep(100);
@@ -690,7 +782,14 @@ public class MonitorManagerTestSuite {
 		
 		// initial condition generate and check here finishes here
 		
-		Thread th0 = new Thread(() -> monitor.fireTransition(t2));
+		Thread th0 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t2);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
+		
 		th0.start();
 		
 		try{
@@ -703,7 +802,13 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(events.isEmpty());
 		
-		Thread th1 = new Thread(() -> monitor.fireTransition(t1));
+		Thread th1 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t1);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th1.start();
 		
 		try{
@@ -735,7 +840,13 @@ public class MonitorManagerTestSuite {
 		
 		Transition t1 = petri.getTransitions()[1];
 		
-		Thread th0 = new Thread(() -> monitor.fireTransition(t1, true));
+		Thread th0 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t1, true);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th0.start();
 		
 		try {
@@ -775,7 +886,13 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(events.isEmpty());
 		
-		Thread th0 = new Thread(() -> monitor.fireTransition(t1, true));
+		Thread th0 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t1, true);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th0.start();
 		
 		try {
@@ -818,7 +935,13 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(events.isEmpty());
 		
-		Thread th0 = new Thread(() -> monitor.fireTransition(t0, true));
+		Thread th0 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t0, true);
+			} catch (Exception e) {
+				Assert.fail("Exception thrown in test execution");
+			}
+		});
 		th0.start();
 		
 		try {
@@ -862,7 +985,11 @@ public class MonitorManagerTestSuite {
 		
 		Assert.assertTrue(events.isEmpty());
 		
-		monitor.fireTransition(t0.getName());
+		try {
+			monitor.fireTransition(t0.getName());
+		} catch (IllegalArgumentException | IllegalTransitionFiringError | NotInitializedTimedPetriNetException e1) {
+			Assert.fail("Exception thrown in test execution");
+		}
 		
 		Assert.assertFalse(events.isEmpty());
 		

--- a/test/unit_tests/MonitorManagerTestSuite.java
+++ b/test/unit_tests/MonitorManagerTestSuite.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import Petri.PetriNet;
 import Petri.PetriNetFactory;
 import Petri.PetriNetFactory.petriNetType;
+import Petri.TimedPetriNet;
 import Petri.Transition;
 import monitor_petri.FirstInLinePolicy;
 import monitor_petri.MonitorManager;
@@ -28,6 +29,7 @@ public class MonitorManagerTestSuite {
 	
 	MonitorManager monitor;
 	PetriNet petri;
+	TimedPetriNet timedPetriNet;
 	static TransitionsPolicy policy;
 	static PetriNetFactory factory;
 	
@@ -59,13 +61,22 @@ public class MonitorManagerTestSuite {
 	}
 	
 	/**
+	 * Creates factory, petri and monitor from given PNML
+	 * @param PNML Path to the PNML file
+	 * @param type The petri type to create
+	 */
+	private void setUpMonitor(String PNML, petriNetType type){
+		factory = new PetriNetFactory(PNML);
+		petri = factory.makePetriNet(type);
+		monitor = new MonitorManager(petri, policy);		
+	}
+	
+	/**
 	 * Creates builder, petri and monitor from given PNML
 	 * @param PNML path to the PNML file
 	 */
 	private void setUpMonitor(String PNML){
-		factory = new PetriNetFactory(PNML);
-		petri = factory.makePetriNet(petriNetType.PT);
-		monitor = new MonitorManager(petri, policy);
+		setUpMonitor(PNML, petriNetType.PT);
 	}
 
 	/**

--- a/test/unit_tests/MonitorManagerTestSuite.java
+++ b/test/unit_tests/MonitorManagerTestSuite.java
@@ -68,7 +68,7 @@ public class MonitorManagerTestSuite {
 	private void setUpMonitor(String PNML, petriNetType type){
 		factory = new PetriNetFactory(PNML);
 		petri = factory.makePetriNet(type);
-		monitor = new MonitorManager(petri, policy);		
+		monitor = new MonitorManager(petri, policy);
 	}
 	
 	/**

--- a/test/unit_tests/MonitorManagerTimeTestSuite.java
+++ b/test/unit_tests/MonitorManagerTimeTestSuite.java
@@ -67,7 +67,7 @@ public class MonitorManagerTimeTestSuite {
 	 * <li> And p0 has one token</li>
 	 * <li> And t0 is timed [a,b], a>0, b>a </li>
 	 * <li> When thread worker fires t0 at time ti < a (before timespan) </li>
-	 * <li> Then worker goes to sleep into transition (not to the varCond queue) </li>
+	 * <li> Then worker goes to sleep by itself </li>
 	 */
 	@Test
 	public void testAThreadGoesToSleepWhenComeBeforeTimeSpan() {
@@ -97,7 +97,7 @@ public class MonitorManagerTimeTestSuite {
 	 * <li> And t0 is timed [a,b], a>0, b>a </li>
 	 * <li> When thread worker1 tries to fires t0 at time ti < a (before timespan) </li>
 	 * <li> And thread worker2 tries to fires t0 at time tj, where ti < tj < a (before timespan as well) </li>
-	 * <li> Then worker1 goes to sleep into transition (not to the varCond queue) </li>
+	 * <li> Then worker1 goes to sleep by itself </li>
 	 * <li> And worker2 goes to sleep into varCond queue </li>
 	 */
 	@Test
@@ -143,7 +143,7 @@ public class MonitorManagerTimeTestSuite {
 	 * <li> And p0 has one token</li>
 	 * <li> And t0 is timed [a,b], a>0, b>a </li>
 	 * <li> When thread worker tries to fires t0 at time ti < a (before timespan) </li>
-	 * <li> Then worker goes to sleep into transition (not to the varCond queue) </li>
+	 * <li> Then worker goes to sleep by itself </li>
 	 * <li> And worker wakes up after the time "a - ti" and fires the transition succefully</li>
 	 */
 	@Test
@@ -354,12 +354,10 @@ public class MonitorManagerTimeTestSuite {
 	/**
 	 * <li> Given t0 is enabled </li>
 	 * <li> And t0 is timed with timespan [a,b], a>0, b>a </li>
-	 * <li> And after set up the petri net, the main thread sleeps simulating the time </li>
-	 * <li> spent in set up the custom software</li>
+	 * <li> And some time passes after initialization </li>
 	 * <li> And the timespans are initialized </li>
-	 * <li> When thread th0 tries to fire t0 at time ti</li>
-	 * <li> Then th0 fires t0 succefully, although it comes before timespan, because in that case </li>
-	 * <li> th0 goes to sleep for a while (a - ti) and then wakes up and fires the transition</li>
+	 * <li> When thread th0 tries to fire t0 </li>
+	 * <li> Then th0 fires t0 succefully </li>
 	 */
 	@Test
 	public void MonitorShouldRestartTheEnablingTimesAndHasNoRaceTimeCondition(){
@@ -389,7 +387,6 @@ public class MonitorManagerTimeTestSuite {
 		
 		expectedMarking[0] = 0;
 		expectedMarking[1] = 1;	
-		Assert.assertArrayEquals(expectedMarking, timedPetriNet.getCurrentMarking());		
+		Assert.assertArrayEquals(expectedMarking, timedPetriNet.getCurrentMarking());
 	}
-
 }

--- a/test/unit_tests/MonitorManagerTimeTestSuite.java
+++ b/test/unit_tests/MonitorManagerTimeTestSuite.java
@@ -402,7 +402,7 @@ public class MonitorManagerTimeTestSuite {
 	 * <li> And some time passes after initialization </li>
 	 * <li> And the timespans are initialized </li>
 	 * <li> When thread th0 tries to fire t0 </li>
-	 * <li> Then th0 fires t0 succefully </li>
+	 * <li> Then th0 fires t0 successfully </li>
 	 */
 	@Test
 	public void MonitorShouldRestartTheEnablingTimesAndHasNoRaceTimeCondition(){
@@ -445,12 +445,11 @@ public class MonitorManagerTimeTestSuite {
 	 * <li> Given t0 is enabled </li>
 	 * <li> And t0 is timed with timespan [a,b], a>0, b>a </li>
 	 * <li> And some time passes after initialization </li>
-	 * <li> And the timespans are initialized </li>
 	 * <li> When thread th0 tries to fire t0 </li>
-	 * <li> Then th0 fires t0 succefully </li>
+	 * <li> Then a NotInitializedTimedPetriNetException is thrown </li>
 	 */
 	@Test
-	public void MonitorShouldThrowsAnExceptionWhenThreadTriesToFireBeforeStartPetriNetTimes(){
+	public void MonitorShouldThrownAnExceptionWhenThreadTriesToFireBeforeStartPetriNetTimes(){
 		
 		setUpMonitor(PETRI_FOR_INITIALIZATION_TIME);
 		
@@ -467,7 +466,7 @@ public class MonitorManagerTimeTestSuite {
 			}
 		});
 		
-		th0.start();		
+		th0.start();	
 		
 		try {
 			Thread.sleep(100);

--- a/test/unit_tests/MonitorManagerTimeTestSuite.java
+++ b/test/unit_tests/MonitorManagerTimeTestSuite.java
@@ -450,7 +450,7 @@ public class MonitorManagerTimeTestSuite {
 	 * <li> Then a NotInitializedTimedPetriNetException is thrown </li>
 	 */
 	@Test
-	public void MonitorShouldThrownAnExceptionWhenThreadTriesToFireBeforeStartPetriNetTimes(){
+	public void MonitorShouldThrowAnExceptionWhenThreadTriesToFireBeforeStartPetriNetTimes(){
 		
 		setUpMonitor(PETRI_FOR_INITIALIZATION_TIME);
 		
@@ -482,10 +482,12 @@ public class MonitorManagerTimeTestSuite {
 	 * <li> Given p0 feeds t1 and p2 feeds t1 </li>
 	 * <li> And t0 and t1 are enabled </li>
 	 * <li> And t0 is timed with timespan [a,b], a>0, b>a </li>
-	 * <li> And t1 has no timespan
+	 * <li> And t1 is not timed </li>
 	 * <li> And some time passes after initialization </li>
-	 * <li> When thread th0 tries to fire t1 </li>
-	 * <li> Then th0 fires t1 successfully </li>
+	 * <li> When th2 tries to fire t0 </li>
+	 * <li> Then a NotInitializedTimedPetriNetException is thrown </li>
+	 * <li> And th0 tries to fire t1 </li>
+	 * <li> And th0 fires t1 successfully </li>
 	 * <li> And th1 tries to fire t0 </li>
 	 * <li> And th1 fires t0 successfully </li>
 	 */
@@ -515,6 +517,16 @@ public class MonitorManagerTimeTestSuite {
 				Assert.fail("Exception thrown in test execution");
 			}
 		});
+		
+		Thread th2 = new Thread(() -> {
+			try {
+				monitor.fireTransition(t0);
+			} catch (Exception e) {
+				Assert.assertEquals(NotInitializedTimedPetriNetException.class, e.getClass());
+			}
+		});
+		
+		th2.start();
 		
 		th0.start();
 		

--- a/test/unit_tests/testResources/timedPetriForInitializationTime.ndr
+++ b/test/unit_tests/testResources/timedPetriForInitializationTime.ndr
@@ -1,0 +1,8 @@
+p 30.0 50.0 p0 1 n
+t 30.0 130.0 t0 20 25 n
+p 30.0 220.0 p1 0 n
+e t0 p1 1 n
+e p0 t0 1 n
+h timedPetriForInitializationTime
+
+

--- a/test/unit_tests/testResources/timedPetriForInitializationTime.pnml
+++ b/test/unit_tests/testResources/timedPetriForInitializationTime.pnml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+ <net id="n-14EC-EE620-0" type ="http://www.laas.fr/tina/tpn">
+  <name>
+   <text>timedPetriForInitializationTime</text>
+  </name>
+ <page id="g-14EC-EE630-1">
+  <place id="p-14EC-EE633-2">
+  <name>
+   <text>p0</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>1</text>
+   </initialMarking>
+   <graphics>
+    <position x="35" y="50"/>
+   </graphics>
+  </place>
+  <place id="p-14EC-EE63F-3">
+  <name>
+   <text>p1</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="35" y="220"/>
+   </graphics>
+  </place>
+  <transition id="t-14EC-EE643-4">
+  <name>
+   <text>t0</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <delay>
+    <interval xmlns="http://www.w3.org/1998/Math/MathML" closure="closed">
+     <cn>20</cn>
+     <cn>202</cn>
+    </interval>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+   </delay>
+   <graphics>
+    <position x="35" y="130"/>
+   </graphics>
+  </transition>
+  <arc id="e-14EC-EE649-5" source="t-14EC-EE643-4" target="p-14EC-EE63F-3">
+  </arc>
+  <arc id="e-14EC-EE64D-6" source="p-14EC-EE633-2" target="t-14EC-EE643-4">
+  </arc>
+ </page>
+ </net>
+</pnml>

--- a/test/unit_tests/testResources/timedPetriForInitializationTime2.ndr
+++ b/test/unit_tests/testResources/timedPetriForInitializationTime2.ndr
@@ -1,0 +1,12 @@
+p 30.0 50.0 p0 1 n
+t 30.0 130.0 t0 20 25 n
+p 30.0 220.0 p1 0 n
+t 115.0 130.0 t1 0 w n
+p 115.0 50.0 p2 1 n
+e t1 p1 1 n
+e p2 t1 1 n
+e p0 t0 1 n
+e t0 p1 1 n
+h timedPetriForInitializationTime2
+
+

--- a/test/unit_tests/testResources/timedPetriForInitializationTime2.pnml
+++ b/test/unit_tests/testResources/timedPetriForInitializationTime2.pnml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+ <net id="n-1BE8-4F8E9-0" type ="http://www.laas.fr/tina/tpn">
+  <name>
+   <text>timedPetriForInitializationTime2</text>
+  </name>
+ <page id="g-1BE8-4F919-1">
+  <place id="p-1BE8-4F921-2">
+  <name>
+   <text>p0</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>1</text>
+   </initialMarking>
+   <graphics>
+    <position x="30" y="50"/>
+   </graphics>
+  </place>
+  <place id="p-1BE8-4F94F-3">
+  <name>
+   <text>p1</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="30" y="220"/>
+   </graphics>
+  </place>
+  <place id="p-1BE8-4F952-4">
+  <name>
+   <text>p2</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>1</text>
+   </initialMarking>
+   <graphics>
+    <position x="115" y="50"/>
+   </graphics>
+  </place>
+  <transition id="t-1BE8-4F956-5">
+  <name>
+   <text>t0</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <delay>
+    <interval xmlns="http://www.w3.org/1998/Math/MathML" closure="closed">
+     <cn>20</cn>
+     <cn>25</cn>
+    </interval>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+   </delay>
+   <graphics>
+    <position x="30" y="130"/>
+   </graphics>
+  </transition>
+  <transition id="t-1BE8-4F95E-6">
+  <name>
+   <text>t1</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="115" y="130"/>
+   </graphics>
+  </transition>
+  <arc id="e-1BE8-4F962-7" source="t-1BE8-4F95E-6" target="p-1BE8-4F94F-3">
+  </arc>
+  <arc id="e-1BE8-4F96B-8" source="p-1BE8-4F952-4" target="t-1BE8-4F95E-6">
+  </arc>
+  <arc id="e-1BE8-4F96D-9" source="p-1BE8-4F921-2" target="t-1BE8-4F956-5">
+  </arc>
+  <arc id="e-1BE8-4F96E-10" source="t-1BE8-4F956-5" target="p-1BE8-4F94F-3">
+  </arc>
+ </page>
+ </net>
+</pnml>


### PR DESCRIPTION
The changes are in TimedPetriNet.
Now, we have a start method that calculates the enabled transitions for first time and the timed petri net constructor has no that responsibility anymore.
Start method is intended to be call just one time, i think that we could protect it

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airabinovich/java_petri_engine/26)

<!-- Reviewable:end -->
