### PR TITLE
Fix issues #7 and #24 for priority inversion in firing timed transitions

### DIFF
--- a/src/Petri/TimedPetriNet.java
+++ b/src/Petri/TimedPetriNet.java
@@ -9,10 +9,10 @@ public class TimedPetriNet extends PetriNet{
 	
 	/**
 	 * Constructs a TimedPetriNet object, which is a {@link PetriNet} object with added time semantics
-	 * @see PetriNet#PetriNet(Place[], Transition[], Arc[], Integer[], Integer[][], Integer[][], Integer[][], Boolean[][], Boolean[][], Integer[][])
 	 * The enabled transitions are not calculated at initialization time, so
-	 * before firing the first transition, they must be calculated @see {@link TimedPetriNet#startTimes()}
+	 * before firing the first transition, they must be calculated {@link TimedPetriNet#startTimes()}.
 	 * Other way to start times is firing a non timed transition before a timed transition
+	 * @see PetriNet#PetriNet(Place[], Transition[], Arc[], Integer[], Integer[][], Integer[][], Integer[][], Boolean[][], Boolean[][], Integer[][])
 	 */
 	public TimedPetriNet(Place[] _places, Transition[] _transitions, Arc[] _arcs, Integer[] _initialMarking,
 			Integer[][] _preI, Integer[][] _posI, Integer[][] _I, Boolean[][] _inhibition, Boolean[][] _resetMatrix, Integer[][] _readerMatrix) {

--- a/src/monitor_petri/FairQueue.java
+++ b/src/monitor_petri/FairQueue.java
@@ -12,7 +12,9 @@ public class FairQueue implements VarCondQueue{
 	 */
 	public FairQueue(){
 		lock = new PriorityBinaryLock();
-		// take the lock so no thread calling sleep can actually take it and continue
+		// take the lock so no permissions are available
+		// and when a thread calls sleep() (or sleepWithHighPriority())
+		// it can't acquire the lock and continue, and must sleep
 		lock.lock();
 	}
 	
@@ -40,11 +42,11 @@ public class FairQueue implements VarCondQueue{
 		return (int) (lock.getHighPriorityQueueLength() + lock.getLowPriorityQueueLength());
 	}
 	
-	public int getHighPriorityThreadsSLeeping(){
+	public int getHighPriorityThreadsSleeping(){
 		return (int) (lock.getHighPriorityQueueLength());
 	}
 	
-	public int getLowPriorityThreadsSLeeping(){
+	public int getLowPriorityThreadsSleeping(){
 		return (int) (lock.getLowPriorityQueueLength());
 	}
 

--- a/src/monitor_petri/FairQueue.java
+++ b/src/monitor_petri/FairQueue.java
@@ -1,40 +1,51 @@
 package monitor_petri;
 
-import java.util.concurrent.Semaphore;
+import monitor_petri.PriorityBinaryLock.LockPriority;
 
 public class FairQueue implements VarCondQueue{
 	
-	private Semaphore sem;
+	private PriorityBinaryLock lock;
 	
 	/**
 	 * A fair sleeping queue for threads. 
 	 * A call to {@link #sleep() sleep} sends the calling thread to sleep until any threads calls {@link #wakeUp() wakeUp}
 	 */
 	public FairQueue(){
-		sem = new Semaphore(0,true);
+		lock = new PriorityBinaryLock();
+		// take the lock so no thread calling sleep can actually take it and continue
+		lock.lock();
 	}
 	
 	public void sleep(){
-		try {
-			sem.acquire();
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		} 
+		lock.lock();
+	}
+	
+	public void sleepWithHighPriority() {
+		lock.lock(LockPriority.HIGH);
 	}
 
 	public void wakeUp() {
 		if(!isEmpty()){
-			sem.release();
+			lock.unlock();
 		}
 	}
 
 	
 	public boolean isEmpty() {
-		return !sem.hasQueuedThreads();
+		return !lock.hasQueuedThreads();
 	}
 
 	@Override
 	public int getSize() {
-		return sem.getQueueLength();
+		return (int) (lock.getHighPriorityQueueLength() + lock.getLowPriorityQueueLength());
 	}
+	
+	public int getHighPriorityThreadsSLeeping(){
+		return (int) (lock.getHighPriorityQueueLength());
+	}
+	
+	public int getLowPriorityThreadsSLeeping(){
+		return (int) (lock.getLowPriorityQueueLength());
+	}
+
 }

--- a/src/monitor_petri/MonitorManager.java
+++ b/src/monitor_petri/MonitorManager.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Optional;
-import java.util.concurrent.Semaphore;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import Petri.PetriNet;
 import Petri.TimeSpan;
 import Petri.Transition;
+import monitor_petri.PriorityBinaryLock.LockPriority;
 import rx.Observer;
 import rx.Subscription;
 import rx.subjects.PublishSubject;
@@ -21,7 +21,7 @@ public class MonitorManager {
 	/** Petri Net to command the monitor orchestration */
 	private PetriNet petri;
 	/** Mutex for the monitor access with a FIFO queue associated*/
-	private Semaphore inQueue = new Semaphore(1,true);
+	private PriorityBinaryLock inQueue = new PriorityBinaryLock();
 	/** Condition variable queues where locked threads will wait */
 	private VarCondQueue[] condVarQueue;	
 	/** The policy to be used for transitions management. This will decide which transition
@@ -111,16 +111,16 @@ public class MonitorManager {
 		if(transitionToFire.getLabel().isAutomatic()){
 			throw new IllegalTransitionFiringError("An automatic transition has tried to be fired manually");
 		}
-		int permitsToRelease = 1;
+		boolean releaseLock = true;
 		try {
 			// take the mutex to access the monitor
-			inQueue.acquire();
-			permitsToRelease = internalFireTransition(transitionToFire, perennialFire);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
+			inQueue.lock();
+			releaseLock = internalFireTransition(transitionToFire, perennialFire);
 		} finally{
 			// the firing is done, release the mutex and leave
-			inQueue.release(permitsToRelease);
+			if(releaseLock){
+				inQueue.unlock();
+			}
 		}
 	}
 	
@@ -209,9 +209,9 @@ public class MonitorManager {
 			throw new NullPointerException("Empty guard name not allowed");
 		}
 		boolean couldSet = false;
-		int permitsToRelease = 1;
+		boolean releaseLock = true;
 		try{
-			inQueue.acquire();
+			inQueue.lock();
 			petri.readGuard(guardName);
 			couldSet = petri.addGuard(guardName, newValue);
 			// setting this guard could've enabled some transitions
@@ -220,17 +220,17 @@ public class MonitorManager {
 			int nextTransitionToFireIndex = getNextTransitionAvailableToFire();
 			if(nextTransitionToFireIndex >= 0){
 				if(petri.getAutomaticTransitions()[nextTransitionToFireIndex]){
-					permitsToRelease = internalFireTransition(petri.getTransitions()[nextTransitionToFireIndex], false);
+					releaseLock = internalFireTransition(petri.getTransitions()[nextTransitionToFireIndex], false);
 				} else {
 					// if a fired transition was enabled by the guard, wake up a thread waiting for it
-					permitsToRelease = 0;
+					releaseLock = false;
 					condVarQueue[nextTransitionToFireIndex].wakeUp();
 				}
 			}
-		} catch(InterruptedException e){
-			e.printStackTrace();
 		} finally {
-			inQueue.release(permitsToRelease);
+			if(releaseLock){
+				inQueue.unlock();
+			}
 		}
 		return couldSet;
 	}
@@ -293,11 +293,10 @@ public class MonitorManager {
 	 * A perennial fire doesn't send a thread to sleep.
 	 * @param transitionToFire
 	 * @param perennialFire
-	 * @return permits to release to mutex {@link #inQueue}
-	 * @throws InterruptedException if the calling thread is interrupted
+	 * @return Whether to release the mutex {@link #inQueue}
 	 */
-	private int internalFireTransition(Transition transitionToFire, boolean perennialFire) throws InterruptedException{
-		int permitsToRelease = 1;
+	private boolean internalFireTransition(Transition transitionToFire, boolean perennialFire){
+		boolean releaseLock = true;
 		boolean keepFiring = true;
 		boolean insideTimeSpan = false;
 		boolean isTimed = false;
@@ -312,24 +311,29 @@ public class MonitorManager {
 			}
 			if(keepFiring){
 				while(isTimed && !insideTimeSpan){
-					//The calling thread came before time span, and there is nobody sleeping in the transition
 					if(transitionSpan.isBeforeTimeSpan(fireAttemptTime) && !transitionSpan.anySleeping()){
-						inQueue.release();
+						// The calling thread came before time span, and there is nobody sleeping in the transition,
+						// release the input mutex and sleep here until the time has come.
+						inQueue.unlock();
 						transitionSpan.sleep(transitionSpan.getEnableTime() + transitionSpan.getTimeBegin() - fireAttemptTime);
-						// TODO: here, the waking thread shouldn't have to wait its turn to enter the monitor
-						// because it's inside its timespan and can miss its chance to fire waiting
-						// Issue #7 has to be fixed here
-						inQueue.acquire();
+						// when this thread wakes up, its time to fire has come and may be short
+						// so take the lock with high priority to avoid waiting for the incoming threads
+						// This way, only as high-prioritized threads as this one may cause waiting
+						inQueue.lock(LockPriority.HIGH);
 					}
 					else if(!perennialFire) {
-						//The calling thread came late, the time is over. Thus the thread releases the input mutex and goes to sleep
-						inQueue.release();
-						condVarQueue[transitionToFire.getIndex()].sleep();
+						// The calling thread came late, the time is over. Thus the thread releases the input mutex and goes to sleep
+						inQueue.unlock();
+						// Go to sleep in the condition queue but with high priority.
+						// This is because when this thread is waken, it'll have a limited amount of time to fire its transition
+						// And this way it won't need to wait for other threads who came after it.
+						// It's going to be the first in line due to timestamp and priority ordering
+						condVarQueue[transitionToFire.getIndex()].sleepWithHighPriority();;
 						// when waking up, don't take the mutex for the waking thread didn't release it
 					}
 					else{
 						// a perennial fire should not wait in the queue for the transition to get enabled again
-						return permitsToRelease;
+						return releaseLock;
 					}
 					// at this point, the transition may have been disabled when the firing thread was sleeping
 					fireAttemptTime = System.currentTimeMillis();
@@ -340,12 +344,12 @@ public class MonitorManager {
 					if(perennialFire){
 						// the firing failed but since it's a perennial fire
 						// the calling thread doesn't have to sleep
-						// so return the permits to be released
-						return permitsToRelease;
+						// so return whether to release the mutex
+						return releaseLock;
 					}
 					// if the transition wasn't fired sucessfully
 					// release the main mutex and go to sleep
-					inQueue.release();
+					inQueue.unlock();
 					condVarQueue[transitionToFire.getIndex()].sleep();
 					// after waking up try to fire inside the timespan again
 					continue;
@@ -367,26 +371,26 @@ public class MonitorManager {
 					else{
 						// The transition chosen isn't automatic
 						// so wake up the associated thread to that transition
-						// and leave the monitor without releasing the input mutex (permits = 0)
+						// and leave the monitor without releasing the input mutex
 						condVarQueue[nextTransitionToFireIndex].wakeUp();
-						permitsToRelease = 0;
+						releaseLock = false;
 						keepFiring = false;
 					}
 				}
 				else{
-					// no transition left to fire, leave the monitor releasing one permit
+					// no transition left to fire, leave the monitor releasing the lock
 					keepFiring = false;
-					permitsToRelease = 1;
+					releaseLock = true;
 				}
 			}
 			// if this is a perennial fire and the transition is not enabled, don't send the thread to sleep
 			else if(!perennialFire){
 				// the fire failed, thus the thread releases the input mutex and goes to sleep
-				inQueue.release();
+				inQueue.unlock();
 				condVarQueue[transitionToFire.getIndex()].sleep();
 				keepFiring = true;
 			}
 		}
-		return permitsToRelease;
+		return releaseLock;
 	}
 }

--- a/src/monitor_petri/PriorityBinaryLock.java
+++ b/src/monitor_petri/PriorityBinaryLock.java
@@ -1,0 +1,225 @@
+package monitor_petri;
+
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * A lock with two priority levels.
+ * There is only one permit available, thus the binary.
+ * Each lock() blocks if necessary until the lock is available, and then takes it.
+ * Each unlock() releases the lock, potentially waking a blocking acquirer.
+ * 
+ * The special feature in this lock is that a {@link #lock(LockPriority)} call may be with high or low priority,
+ * and a {@link #unlock()} call prioritizes a high priority caller.
+ * That is, a thread sleeping with high priority will be released before a low priority one.
+ * 
+ * Among threads of the same priority level, the lock's queue behaves as a FIFO queue.
+ *
+ * @see LockPriority
+ */
+public class PriorityBinaryLock {
+
+	/** Atomic boolean object to take register of the lock and guarantee no concurrence errors may allow two threads to take it */
+	private final AtomicBoolean locked = new AtomicBoolean(false);
+	
+	/** 
+	 * The container to organize the sleeping threads.
+	 * This is ordered by priority and by arrival time among same priority level threads
+	 */
+	private final PriorityBlockingQueue<PrioritizedThread> queue = new PriorityBlockingQueue<PrioritizedThread>();
+	
+	/** A counter for low priority sleeping threads */
+	private AtomicLong lowPriorityThreadsSleeping = new AtomicLong(0);
+	/** A counter for high priority sleeping threads */
+	private AtomicLong highPriorityThreadsSleeping = new AtomicLong(0); 
+	
+	/**
+	 * Available priorities for {@link PriorityBinaryLock}
+	 */
+	public enum LockPriority{
+		HIGH,
+		LOW
+	}
+	
+	/**
+	 * Creates a PriorityBinaryLock.
+	 */
+	public PriorityBinaryLock() {
+	}
+	
+	/**
+	 * Tries to lock this PriorityLock with low priority.
+	 * Takes the lock if available and returns immediately,
+	 * else the current thread becomes disabled for thread scheduling purposes and lies dormant until
+	 * some other thread invokes the {@link #unlock()} method for this lock
+	 * and the current thread is next in line.
+	 */
+	public void lock(){
+		lock(LockPriority.LOW);
+	}
+	
+	/**
+	 * Tries to lock this PriorityLock with the specified priority.
+	 * Takes the lock if available and returns immediately,
+	 * else the current thread becomes disabled for thread scheduling purposes and lies dormant until
+	 * some other thread invokes the {@link #unlock()} method for this lock
+	 * and the current thread is next in line.
+	 */
+	public void lock(LockPriority priority){
+
+		PrioritizedThread entry = new PrioritizedThread(Thread.currentThread(), priority);
+		queue.add(entry);
+
+		switch(priority){
+		case HIGH:
+			highPriorityThreadsSleeping.incrementAndGet();
+			break;
+		case LOW:
+			lowPriorityThreadsSleeping.incrementAndGet();
+			break;
+		}
+		// Block while not first in queue or cannot acquire lock
+		while(queue.peek() != entry || !locked.compareAndSet(false, true)){
+
+			LockSupport.park(this); // disable the current thread with the semaphore as permit
+			// this is inside a while just in case. It's recommended
+		}
+		
+		// once the lock is taken by the current thread, remove it from the queue
+		queue.remove(entry);
+		
+		switch(priority){
+		case HIGH:
+			highPriorityThreadsSleeping.decrementAndGet();
+			break;
+		case LOW:
+			lowPriorityThreadsSleeping.decrementAndGet();
+			break;
+		}
+	}
+	
+	/**
+	 * Releases this lock.
+	 * If there's any thread waiting for it, wake it up.
+	 * Which thread is to be woken is {@link #queue}'s responsibility.
+	 */
+	public void unlock() {
+		locked.set(false);
+		// wakes the first thread in priority order if any
+		if(!queue.isEmpty()){
+			LockSupport.unpark(queue.peek().getThread());
+		}
+		// if the queue is empty, no thread tried to acquire the lock
+		// while the current thread had the lock
+	}
+	
+
+	
+	/**
+	 * Returns the length of the low priority queue
+	 * @return the number of threads waiting for this lock with low priority
+	 */
+	public long getLowPriorityQueueLength(){
+		return lowPriorityThreadsSleeping.get();
+	}
+	/**
+	 * Returns the length of the high priority queue
+	 * @return the number of threads waiting for this lock with high priority
+	 */
+	public long getHighPriorityQueueLength(){
+		return highPriorityThreadsSleeping.get();
+	}
+	
+	/**
+	 * Tests the lock and informs if it's taken
+	 * @return True if the lock is taken
+	 */
+	public boolean isLocked(){
+		return locked.get();
+	}
+	
+	/**
+	 * @return True if there are threads waiting to take this lock
+	 */
+	public boolean hasQueuedThreads(){
+		return (highPriorityThreadsSleeping.get() != 0L) ||
+				(lowPriorityThreadsSleeping.get() != 0L);
+	}
+
+	/**
+	 * A container for threads to be compared.
+	 * The comparison is to be made first using {@link LockPriority} and only then by creation time.
+	 * The natural order is that high priority threads are on top of low,
+	 * and among same priority level threads, older threads come first.
+	 */
+	private class PrioritizedThread implements Comparable<PrioritizedThread> {
+
+		/** The contained Thread */
+		private Thread thread;
+		/** The thread calling priority */
+		private LockPriority priority;
+		/** Object's creation time */
+		private long timestamp;
+		
+		/**
+		 * Constructs the {@link PrioritizedThread} object wrapping the given thread associated with the given priority.
+		 * Also a timestamp is generated at construction time for comparison.
+		 * @param _thread The thread to wrap.
+		 * @param _priority The priority of the thread.
+		 * @throws NullPointerException If thread or priority is null
+		 */
+		public PrioritizedThread(Thread _thread, LockPriority _priority) throws NullPointerException {
+			if(_thread == null || _priority == null){
+				throw new NullPointerException("No null thread nor priority allowed");
+			}
+			
+			thread = _thread;
+			priority = _priority;
+			timestamp = System.currentTimeMillis();
+			
+		}
+		
+		/**
+		 * @return The thread priority
+		 */
+		public final LockPriority getPriority(){
+			return priority;
+		}
+		
+		/**
+		 * The format of this timestamp is the format of {@link System#currentTimeMillis()}
+		 * @return Object's creation time
+		 */
+		public final long getTimestamp(){
+			return timestamp;
+		}
+		
+		/**
+		 * @return The wrapped thread
+		 */
+		public final Thread getThread(){
+			return thread;
+		}
+		
+		@Override
+		public int compareTo(PrioritizedThread _prioritizedThread) {
+			int priorityComparison = priority.compareTo(_prioritizedThread.getPriority());
+			
+			if(priorityComparison < 0){
+				// this thread has higher priority
+				return -1;
+			}
+			
+			if(priorityComparison > 0){
+				// the other thread has higher priority
+				return 1;
+			}
+			
+			//both threads have same priority, return the one with the lower timestamp
+			return (timestamp - _prioritizedThread.getTimestamp()) < 0 ? -1 : 1;
+		}
+		
+	}
+}

--- a/src/monitor_petri/PriorityBinaryLock.java
+++ b/src/monitor_petri/PriorityBinaryLock.java
@@ -7,7 +7,7 @@ import java.util.concurrent.locks.LockSupport;
 
 /**
  * A lock with two priority levels.
- * There is only one permit available, thus the binary.
+ * There is only one permit available, thus the 'binary' in the class' name.
  * Each lock() blocks if necessary until the lock is available, and then takes it.
  * Each unlock() releases the lock, potentially waking a blocking acquirer.
  * 
@@ -108,8 +108,10 @@ public class PriorityBinaryLock {
 	public void unlock() {
 		locked.set(false);
 		// wakes the first thread in priority order if any
-		if(!queue.isEmpty()){
+		try{
 			LockSupport.unpark(queue.peek().getThread());
+		} catch (NullPointerException e){
+			// queue was empty, no problem
 		}
 		// if the queue is empty, no thread tried to acquire the lock
 		// while the current thread had the lock

--- a/src/monitor_petri/VarCondQueue.java
+++ b/src/monitor_petri/VarCondQueue.java
@@ -8,6 +8,13 @@ public interface VarCondQueue{
 	public void sleep();
 	
 	/**
+	 * Sends the calling thread to sleep with the guarantee
+	 * that a {@link #wakeUp()} call will signal it before any other
+	 * thread who called {@link #sleep()}
+	 */
+	public void sleepWithHighPriority();
+	
+	/**
 	 * Wakes a sleeping thread up if there is any.
 	 * The woken thread is the one that has been waiting the longer
 	 */

--- a/test/test_utils/DummyTask.java
+++ b/test/test_utils/DummyTask.java
@@ -5,16 +5,22 @@ import monitor_petri.VarCondQueue;
 public class DummyTask extends Thread{
 		
 	private boolean get_in_queue;
+	private boolean get_in_high_priority_queue;
 	private boolean terminate;
 	VarCondQueue queue;
 	
 	public DummyTask(VarCondQueue q){
 		queue = q;
 		get_in_queue = false;
+		get_in_high_priority_queue = false;
 	}
 	
 	public synchronized void setGet_in_queue(boolean _get_in_queue){
 		get_in_queue = _get_in_queue;
+	}
+	
+	public synchronized void setGet_in_high_priority_queue(boolean _get_in_high_priority_queue){
+		get_in_high_priority_queue = _get_in_high_priority_queue;
 	}
 	
 	public synchronized void setTerminate(boolean _terminate){
@@ -25,15 +31,20 @@ public class DummyTask extends Thread{
 	public void run() {
 		while(!terminate){
 			try {
-				if(get_in_queue){
+				if(get_in_high_priority_queue){
+					queue.sleepWithHighPriority();
+					setGet_in_high_priority_queue(false);
+				}
+				else if(get_in_queue){
 					queue.sleep();
 					setGet_in_queue(false);
 				}
-				Thread.sleep(100);
+				Thread.sleep(10);
 			} catch (InterruptedException e) {
 			}
 		}
 		setGet_in_queue(false);
+		setGet_in_high_priority_queue(false);
 		setTerminate(false);
 	}
 }

--- a/test/unit_tests/FairQueueTestSuite.java
+++ b/test/unit_tests/FairQueueTestSuite.java
@@ -112,8 +112,8 @@ public class FairQueueTestSuite {
 			Assert.fail("Main thread interrupted during test execution");
 		}
 		
-		Assert.assertEquals(3, queue.getLowPriorityThreadsSLeeping());
-		Assert.assertEquals(2, queue.getHighPriorityThreadsSLeeping());
+		Assert.assertEquals(3, queue.getLowPriorityThreadsSleeping());
+		Assert.assertEquals(2, queue.getHighPriorityThreadsSleeping());
 		
 		queue.wakeUp();
 		
@@ -131,8 +131,8 @@ public class FairQueueTestSuite {
 			Assert.fail("Main thread interrupted during test execution");
 		}
 		
-		Assert.assertEquals(3, queue.getLowPriorityThreadsSLeeping());
-		Assert.assertEquals(0, queue.getHighPriorityThreadsSLeeping());
+		Assert.assertEquals(3, queue.getLowPriorityThreadsSleeping());
+		Assert.assertEquals(0, queue.getHighPriorityThreadsSleeping());
 		
 	}
 

--- a/test/unit_tests/FairQueueTestSuite.java
+++ b/test/unit_tests/FairQueueTestSuite.java
@@ -86,5 +86,54 @@ public class FairQueueTestSuite {
 		Assert.assertTrue(queue.isEmpty());
 		
 	}
+	
+	/**
+	 * <li> Given 3 threads go to sleep </li>
+	 * <li> And 2 threads go to sleep with high priority </li>
+	 * <li> When I wake up 2 threads </li>
+	 * <li> Then no high priority threads are sleeping </li>
+	 * <li> And 3 low priority threads are sleeping </li>
+	 */
+	@Test
+	public void threadSleepingWithHighPriorityIsWakenBeforeLowPriorityThread(){
+		Assert.assertTrue(queue.isEmpty());
+		
+		for(int i = 0; i < 3; i++){
+			threads.get(i).setGet_in_queue(true);
+		}
+		
+		for(int i = 3; i < 5; i++){
+			threads.get(i).setGet_in_high_priority_queue(true);
+		}
+		
+		try {
+			Thread.sleep(200);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted during test execution");
+		}
+		
+		Assert.assertEquals(3, queue.getLowPriorityThreadsSLeeping());
+		Assert.assertEquals(2, queue.getHighPriorityThreadsSLeeping());
+		
+		queue.wakeUp();
+		
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted during test execution");
+		}
+		
+		queue.wakeUp();
+		
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted during test execution");
+		}
+		
+		Assert.assertEquals(3, queue.getLowPriorityThreadsSLeeping());
+		Assert.assertEquals(0, queue.getHighPriorityThreadsSLeeping());
+		
+	}
 
 }

--- a/test/unit_tests/FairQueueTestSuite.java
+++ b/test/unit_tests/FairQueueTestSuite.java
@@ -88,7 +88,7 @@ public class FairQueueTestSuite {
 	}
 	
 	/**
-	 * <li> Given 3 threads go to sleep </li>
+	 * <li> Given 3 threads go to sleep with low priority </li>
 	 * <li> And 2 threads go to sleep with high priority </li>
 	 * <li> When I wake up 2 threads </li>
 	 * <li> Then no high priority threads are sleeping </li>

--- a/test/unit_tests/MonitorManagerTimeTestSuite.java
+++ b/test/unit_tests/MonitorManagerTimeTestSuite.java
@@ -601,6 +601,14 @@ public class MonitorManagerTimeTestSuite {
 		
 		th0.start();
 		
+		try {
+			Thread.sleep(10);
+		} catch (InterruptedException e) {
+			Assert.fail("Interrupted thread: " + e.getMessage());
+		}
+		
+		Assert.assertTrue(t0.getTimeSpan().anySleeping());
+		
 		Assert.assertTrue(events.isEmpty());
 		
 		for(Thread worker : workers){
@@ -653,7 +661,7 @@ public class MonitorManagerTimeTestSuite {
 	* <li> And t0 gets enabled </li>
 	* <li> And th0 wakes up and fires t0 </li>
 	* <li> And obs got only one message with t0's ID </li>
-	* <li> And th0's final state is TERMIANTED </li>
+	* <li> And th0's final state is TERMINATED </li>
 	* <li> And all of the other threads' states are WAITING </li>
 	
 	*/
@@ -701,6 +709,8 @@ public class MonitorManagerTimeTestSuite {
 		} catch (InterruptedException e) {
 			Assert.fail("Interrupted thread: " + e.getMessage());
 		}
+		
+		Assert.assertTrue(t0.getTimeSpan().anySleeping());
 		
 		for(Thread worker : workers){
 			worker.start();

--- a/test/unit_tests/PriorityBinaryLockTestSuite.java
+++ b/test/unit_tests/PriorityBinaryLockTestSuite.java
@@ -38,7 +38,7 @@ public class PriorityBinaryLockTestSuite {
 	}
 
 	/**
-	 * <li> Given lock l0 is gets locked </li>
+	 * <li> Given lock l0 gets locked </li>
 	 * <li> And l0's low priority queue is empty </li>
 	 * <li> When thread th0 tries to lock l0 </li>
 	 * <li> Then th0 sleeps in l0's low priority queue </li>
@@ -76,7 +76,7 @@ public class PriorityBinaryLockTestSuite {
 	}
 	
 	/**
-	 * <li> Given lock l0 is gets locked </li>
+	 * <li> Given lock l0 gets locked </li>
 	 * <li> And l0's low priority queue is empty </li>
 	 * <li> When thread th0 tries to lock l0 with low priority </li>
 	 * <li> Then th0 sleeps in l0's low priority queue </li>
@@ -114,7 +114,7 @@ public class PriorityBinaryLockTestSuite {
 	}
 	
 	/**
-	 * <li> Given lock l0 is gets locked </li>
+	 * <li> Given lock l0 gets locked </li>
 	 * <li> And l0's low priority queue is empty </li>
 	 * <li> When thread th0 tries to lock l0 with high priority </li>
 	 * <li> Then th0 sleeps in l0's high priority queue </li>
@@ -317,7 +317,7 @@ public class PriorityBinaryLockTestSuite {
 	 * <li> And l0's low priority queue is empty </li>
 	 * <li> And l0's high priority queue is empty </li>
 	 * <li> When 50 threads try to take l0 with low priority </li>
-	 * <li> And 50 threads try to take l0 with low priority </li>
+	 * <li> And 50 threads try to take l0 with high priority </li>
 	 * <li> And l0's low priority queue has 50 threads </li>
 	 * <li> And l0's high priority queue has 50 threads </li>
 	 * <li> And l0 is unlocked 50 times </li>

--- a/test/unit_tests/PriorityBinaryLockTestSuite.java
+++ b/test/unit_tests/PriorityBinaryLockTestSuite.java
@@ -269,8 +269,8 @@ public class PriorityBinaryLockTestSuite {
 	 * <li> Given l0 is locked </li>
 	 * <li> And l0's low priority queue is empty </li>
 	 * <li> And l0's high priority queue is empty </li>
-	 * <li> When thread th0 tries to lock l0 with low priority </li>
-	 * <li> And th0 goes to sleep in low priority queue </li>
+	 * <li> When thread th0 tries to lock l0 with high priority </li>
+	 * <li> And th0 goes to sleep in high priority queue </li>
 	 * <li> And I unlock l0 </li>
 	 * <li> Then th0 wakes up and executes its task </li>
 	 * <li> And l0's low priority queue has no threads sleeping </li>

--- a/test/unit_tests/PriorityBinaryLockTestSuite.java
+++ b/test/unit_tests/PriorityBinaryLockTestSuite.java
@@ -1,0 +1,398 @@
+package unit_tests;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import monitor_petri.PriorityBinaryLock;
+import monitor_petri.PriorityBinaryLock.LockPriority;
+
+public class PriorityBinaryLockTestSuite {
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	/**
+	 * <li> Given lock l0 is gets locked </li>
+	 * <li> And l0's low priority queue is empty </li>
+	 * <li> When thread th0 tries to lock l0 </li>
+	 * <li> Then th0 sleeps in l0's low priority queue </li>
+	 * <li> And l0's low priority queue has one thread sleeping </li>
+	 */
+	@Test
+	public void acquireTakenLockShouldSleepInLowPriorityQueue() {
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+		
+		l0.lock();
+		
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e1) {
+			Assert.fail("Thread interrupted during test execution");
+		}
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		
+		Thread th0 = new Thread(() -> {
+			l0.lock();
+			Assert.fail("This thread should not reach this point");
+		});
+		
+		th0.start();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(1, l0.getLowPriorityQueueLength());
+	}
+	
+	/**
+	 * <li> Given lock l0 is gets locked </li>
+	 * <li> And l0's low priority queue is empty </li>
+	 * <li> When thread th0 tries to lock l0 with low priority </li>
+	 * <li> Then th0 sleeps in l0's low priority queue </li>
+	 * <li> And l0's low priority queue has one thread sleeping </li>
+	 */
+	@Test
+	public void acquireTakenLockWithLowPriorityShouldSleepInLowPriorityQueue() {
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+		
+		l0.lock();
+		
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e1) {
+			Assert.fail("Thread interrupted during test execution");
+		}
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		
+		Thread th0 = new Thread(() -> {
+			l0.lock(LockPriority.LOW);
+			Assert.fail("This thread should not reach this point");
+		});
+		
+		th0.start();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(1, l0.getLowPriorityQueueLength());
+	}
+	
+	/**
+	 * <li> Given lock l0 is gets locked </li>
+	 * <li> And l0's low priority queue is empty </li>
+	 * <li> When thread th0 tries to lock l0 with high priority </li>
+	 * <li> Then th0 sleeps in l0's high priority queue </li>
+	 * <li> And l0's high priority queue has one thread sleeping </li>
+	 */
+	@Test
+	public void acquireTakenLockWithHighPriorityShouldSleepInHighPriorityQueue() {
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+		
+		l0.lock();
+		
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e1) {
+			Assert.fail("Thread interrupted during test execution");
+		}
+		
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+		
+		Thread th0 = new Thread(() -> {
+			l0.lock(LockPriority.HIGH);
+			Assert.fail("This thread should not reach this point");
+		});
+		
+		th0.start();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(1, l0.getHighPriorityQueueLength());
+	}
+	
+	/**
+	 * <li> Given l0 is locked </li>
+	 * <li> And l0's low priority queue is empty </li>
+	 * <li> And l0's high priority queue is empty </li>
+	 * <li> When thread th0 tries to lock l0 with high priority </li>
+	 * <li> And th0 goes to sleep in high priority queue </li>
+	 * <li> And thread th1 tries to lock l0 with low priority </li>
+	 * <li> And th1 goes to sleep in low priority queue </li>
+	 * <li> And I unlock l0 </li>
+	 * <li> Then th0 wakes up and executes its task </li>
+	 * <li> And th1 never wakes up </li>
+	 * <li> And l0's low priority queue has one thread sleeping </li>
+	 * <li> And l0's high priority queue has no threads sleeping </li>
+	 */
+	@Test
+	public void releaseLockShouldWakeUpThreadSleepingInHighPriorityQueueFirst() {
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+				
+		l0.lock();
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+		
+		FutureTask<Boolean> ft0 = new FutureTask<Boolean>(() -> {
+			l0.lock(LockPriority.HIGH);
+			return true;
+		});
+		Thread th0 = new Thread(ft0);
+		th0.start();
+		
+		FutureTask<Boolean> ft1 = new FutureTask<Boolean>(() -> {
+			l0.lock(LockPriority.LOW);
+			return true;
+		});
+		Thread th1 = new Thread(ft1);
+		th1.start();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		l0.unlock();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+
+		try{
+			ft1.get(1, TimeUnit.MILLISECONDS);
+			Assert.fail("Should not get to this point");
+		} catch (TimeoutException e){
+			//nothing wrong, just timed out because it's locked
+		} catch (Exception e){
+			Assert.fail("Unexpected exception thrown");
+		}
+		try {
+			Assert.assertTrue(ft0.get());
+		} catch (InterruptedException | ExecutionException e) {
+			Assert.fail("Thread interrupted during test execution");
+		}
+	}
+	
+	/**
+	 * <li> Given l0 is locked </li>
+	 * <li> And l0's low priority queue is empty </li>
+	 * <li> And l0's high priority queue is empty </li>
+	 * <li> When thread th0 tries to lock l0 with low priority </li>
+	 * <li> And th0 goes to sleep in low priority queue </li>
+	 * <li> And I unlock l0 </li>
+	 * <li> Then th0 wakes up and executes its task </li>
+	 * <li> And l0's low priority queue has no threads sleeping </li>
+	 * <li> And l0's high priority queue has no threads sleeping </li>
+	 */
+	@Test
+	public void releaseLockShouldWakeUpThreadSleepingInLowPriorityQueueIfHighIsEmpty(){
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+		
+		l0.lock();
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+		
+		Thread th0 = new Thread(() -> {
+			l0.lock(LockPriority.LOW);
+		});
+		th0.start();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(1, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+		
+		l0.unlock();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+	}
+
+	/**
+	 * <li> Given l0 is locked </li>
+	 * <li> And l0's low priority queue is empty </li>
+	 * <li> And l0's high priority queue is empty </li>
+	 * <li> When thread th0 tries to lock l0 with low priority </li>
+	 * <li> And th0 goes to sleep in low priority queue </li>
+	 * <li> And I unlock l0 </li>
+	 * <li> Then th0 wakes up and executes its task </li>
+	 * <li> And l0's low priority queue has no threads sleeping </li>
+	 * <li> And l0's high priority queue has no threads sleeping </li>
+	 */
+	@Test
+	public void releaseLockShouldWakeUpThreadSleepingInHighPriorityQueueIfHighIsEmpty(){
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+		
+		l0.lock();
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+		
+		Thread th0 = new Thread(() -> {
+			l0.lock(LockPriority.HIGH);
+		});
+		th0.start();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(1, l0.getHighPriorityQueueLength());
+		
+		l0.unlock();
+		
+		try {
+			Thread.sleep(50);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+	}
+	
+	/**
+	 * <li> Given l0 gets locked </li>
+	 * <li> And l0's low priority queue is empty </li>
+	 * <li> And l0's high priority queue is empty </li>
+	 * <li> When 50 threads try to take l0 with low priority </li>
+	 * <li> And 50 threads try to take l0 with low priority </li>
+	 * <li> And l0's low priority queue has 50 threads </li>
+	 * <li> And l0's high priority queue has 50 threads </li>
+	 * <li> And l0 is unlocked 50 times </li>
+	 * <li> Then l0's low priority queue has 50 threads </li>
+	 * <li> And l0's high priority queue is empty </li>
+	 */
+	@Test
+	public void multipleUnlocksShouldWakeAllHighPriorityThreadsFirst(){
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+		
+		l0.lock();
+		
+		Assert.assertEquals(0, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+		
+		boolean isHighPriority = true;
+		for(int i = 0; i < 100; i++){
+			if(isHighPriority){
+				new Thread(() -> l0.lock(LockPriority.HIGH)).start();
+			}
+			else{
+				new Thread(
+						() -> {
+							l0.lock(LockPriority.LOW);
+							Assert.fail("Should've not reached this point");
+						}
+						)
+						.start();
+			}
+			isHighPriority = !isHighPriority;
+		}
+		
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e) {
+			Assert.fail("Main thread interrupted");
+		}
+		
+		Assert.assertEquals(50, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(50, l0.getHighPriorityQueueLength());
+		
+		for(int i = 0; i < 50; i++){
+			l0.unlock();
+			try {
+				// give the waken thread a little time to actually get out of the lock
+				Thread.sleep(1);
+			} catch (InterruptedException e) {
+				Assert.fail("Main thread interrupted");
+			}
+		}
+		
+		Assert.assertEquals(50, l0.getLowPriorityQueueLength());
+		Assert.assertEquals(0, l0.getHighPriorityQueueLength());
+	}
+	
+	/**
+	 * <li> Given lock l0 is not taken </li>
+	 * <li> When I try to unlock l0 </li>
+	 * <li> Then l0 remains unlocked </li>
+	 * <li> And no exception is thrown </li>
+	 */
+	@Test
+	public void unlockingNonTakenLockShouldHaveNoEffect(){
+		
+		PriorityBinaryLock l0 = new PriorityBinaryLock();
+		
+		Assert.assertFalse(l0.isLocked());
+		
+		try{
+			l0.unlock();
+			
+			Assert.assertFalse(l0.isLocked());
+		} catch (Exception e) {
+			Assert.fail("No exception should've been thrown: " + e.getMessage());
+		}
+	}
+}

--- a/test/unit_tests/testResources/timedPetri02.ndr
+++ b/test/unit_tests/testResources/timedPetri02.ndr
@@ -1,0 +1,13 @@
+t 220.0 50.0 t1 c 0 w n {<D,I>} e
+t 220.0 145.0 t2 c 0 w n {<D,I>} e
+p 220.0 255.0 p2 0 n
+p 95.0 50.0 p0 1 n
+p 95.0 260.0 p1 0 n
+t 95.0 150.0 t0 c 50 100 w {<D,I>} e
+e t2 p2 1 n
+e t0 p1 1 n
+e p0 t0 1 n
+e p0 t1 1 n
+h timedPetri02
+
+

--- a/test/unit_tests/testResources/timedPetri02.pnml
+++ b/test/unit_tests/testResources/timedPetri02.pnml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pnml xmlns="http://www.pnml.org/version-2009/grammar/pnml">
+ <net id="n-58EA-91B72-0" type ="http://www.laas.fr/tina/tpn">
+  <name>
+   <text>timedPetri02</text>
+  </name>
+ <page id="g-58EA-91B77-1">
+  <place id="p-58EA-91B78-2">
+  <name>
+   <text>p0</text>
+    <graphics>
+     <offset x="-10" y="0" />
+    </graphics>
+  </name>
+   <initialMarking>
+    <text>1</text>
+   </initialMarking>
+   <graphics>
+    <position x="95" y="115"/>
+   </graphics>
+  </place>
+  <place id="p-58EA-91B7D-3">
+  <name>
+   <text>p1</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="95" y="325"/>
+   </graphics>
+  </place>
+  <place id="p-58EA-91B82-4">
+  <name>
+   <text>p2</text>
+    <graphics>
+     <offset x="0" y="-10" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="220" y="320"/>
+   </graphics>
+  </place>
+  <transition id="t-58EA-91B83-5">
+  <name>
+   <text>t0</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <label>
+    <text>&lt;D,I&gt;</text>
+    <graphics>
+     <offset x="10" y="0" />
+    </graphics>
+   </label>
+   <delay>
+    <interval xmlns="http://www.w3.org/1998/Math/MathML" closure="closed">
+     <cn>50</cn>
+     <cn>100</cn>
+    </interval>
+    <graphics>
+     <offset x="-10" y="0" />
+    </graphics>
+   </delay>
+   <graphics>
+    <position x="95" y="215"/>
+   </graphics>
+  </transition>
+  <transition id="t-58EA-91B88-6">
+  <name>
+   <text>t1</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <label>
+    <text>&lt;D,I&gt;</text>
+    <graphics>
+     <offset x="10" y="0" />
+    </graphics>
+   </label>
+   <graphics>
+    <position x="220" y="115"/>
+   </graphics>
+  </transition>
+  <transition id="t-58EA-91B8B-7">
+  <name>
+   <text>t2</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <label>
+    <text>&lt;D,I&gt;</text>
+    <graphics>
+     <offset x="10" y="0" />
+    </graphics>
+   </label>
+   <graphics>
+    <position x="220" y="210"/>
+   </graphics>
+  </transition>
+  <transition id="t-58EA-91B8E-8">
+  <name>
+   <text>t3</text>
+    <graphics>
+     <offset x="0" y="0" />
+    </graphics>
+  </name>
+   <graphics>
+    <position x="95" y="25"/>
+   </graphics>
+  </transition>
+  <arc id="e-58EA-91B8F-9" source="t-58EA-91B8E-8" target="p-58EA-91B78-2">
+  </arc>
+  <arc id="e-58EA-91B91-10" source="t-58EA-91B8B-7" target="p-58EA-91B82-4">
+  </arc>
+  <arc id="e-58EA-91B91-11" source="t-58EA-91B83-5" target="p-58EA-91B7D-3">
+  </arc>
+  <arc id="e-58EA-91B92-12" source="p-58EA-91B78-2" target="t-58EA-91B83-5">
+  </arc>
+  <arc id="e-58EA-91B93-13" source="p-58EA-91B78-2" target="t-58EA-91B88-6">
+  </arc>
+ </page>
+ </net>
+</pnml>


### PR DESCRIPTION
New class PriorityBinaryLock, a lock with two priority levels.
MonitorManager and FairQueue now use PriorityLock instead of Semaphore for their queues.
VarCondQueue adds a new method for high priority sleep.
Added tests for PriorityLock and FairQueue.

Tests for actual priority inversion are needed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airabinovich/java_petri_engine/27)

<!-- Reviewable:end -->
