### PR TITLE
Thread sleeping for a transition before its time span will now sleep in PetriMonitor class

### DIFF
--- a/src/org/unc/lac/javapetriconcurrencymonitor/petrinets/components/TimeSpan.java
+++ b/src/org/unc/lac/javapetriconcurrencymonitor/petrinets/components/TimeSpan.java
@@ -8,8 +8,6 @@ public class TimeSpan {
 	private long timeEnd;
 	/** Timestamp when the transition was enabled */
 	private long enableTime;
-	/** This is true when a thread is sleeping in sleep method */
-	private boolean sleeping;
 	
 	/**
 	 * @param timeB Increment to add to enabling time to set begin time
@@ -82,27 +80,5 @@ public class TimeSpan {
 		else{
 			throw new IllegalArgumentException("The interval time must not have a negative value");
 		}
-	}
-	
-	/**
-	 * Locks the calling thread for the given time
-	 * @param time time to lock the calling thread
-	 */
-	public void sleep(long time){
-		this.sleeping = true;
-		try {
-			Thread.sleep(time);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
-		this.sleeping = false;
-	}
-	
-	/**
-	 * 
-	 * @return true if a thread is locked in {@link #sleep(long time)} method
-	 */
-	public boolean anySleeping(){
-		return sleeping;
 	}
 }

--- a/test/org/lac/javapetriconcurrencymonitor/test/cases/PetriMonitorTimeTestSuite.java
+++ b/test/org/lac/javapetriconcurrencymonitor/test/cases/PetriMonitorTimeTestSuite.java
@@ -83,7 +83,7 @@ public class PetriMonitorTimeTestSuite {
 			e.printStackTrace();
 		}
 		
-		assertEquals(true, t0.getTimeSpan().anySleeping());
+		assertEquals(true, monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 	}
 	
 	/**
@@ -136,7 +136,7 @@ public class PetriMonitorTimeTestSuite {
 			e.printStackTrace();
 		}
 			
-		assertEquals(true, t0.getTimeSpan().anySleeping());
+		assertEquals(true, monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 		assertEquals(true, monitor.getQueuesState()[0]);
 		assertArrayEquals(initialMarking, timedPetriNet.getCurrentMarking());
 	}
@@ -174,7 +174,7 @@ public class PetriMonitorTimeTestSuite {
 			e.printStackTrace();
 		}
 		
-		assertEquals(true, t0.getTimeSpan().anySleeping());
+		assertEquals(true, monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 		
 		try {
 			Thread.sleep(t0BeginTime);
@@ -209,7 +209,7 @@ public class PetriMonitorTimeTestSuite {
 		Assert.assertTrue(timedPetriNet.isEnabled(t0));
 		Assert.assertTrue(timedPetriNet.isEnabled(t3));
 		
-		Assert.assertFalse(t0.getTimeSpan().anySleeping());
+		Assert.assertFalse(monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 		
 		Thread th0 = new Thread(() -> {
 			try {
@@ -230,7 +230,7 @@ public class PetriMonitorTimeTestSuite {
 		boolean insideTimeSpan = t0.getTimeSpan().inTimeSpan(System.currentTimeMillis());
 		
 		Assert.assertFalse(insideTimeSpan);
-		Assert.assertTrue(t0.getTimeSpan().anySleeping());
+		Assert.assertTrue(monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 		
 		Assert.assertTrue(timedPetriNet.isEnabled(t0));
 		Assert.assertTrue(timedPetriNet.isEnabled(t3));
@@ -306,6 +306,8 @@ public class PetriMonitorTimeTestSuite {
 		
 		//let's make sure th0 isn't sleeping in t0's queue
 		Assert.assertFalse(monitor.getQueuesState()[0]);
+		
+		Assert.assertTrue(monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 
 		try {
 			// let's give th0 enough time to wake up and fire t0
@@ -568,7 +570,7 @@ public class PetriMonitorTimeTestSuite {
 			Assert.fail("Interrupted thread: " + e.getMessage());
 		}
 		
-		Assert.assertTrue(t0.getTimeSpan().anySleeping());
+		Assert.assertTrue(monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 		
 		Assert.assertTrue(events.isEmpty());
 		
@@ -671,7 +673,7 @@ public class PetriMonitorTimeTestSuite {
 			Assert.fail("Interrupted thread: " + e.getMessage());
 		}
 		
-		Assert.assertTrue(t0.getTimeSpan().anySleeping());
+		Assert.assertTrue(monitor.isAnyThreadSleepingForTransition(t0.getIndex()));
 		
 		for(Thread worker : workers){
 			worker.start();


### PR DESCRIPTION
Removed every thread management logic from TimeSpan.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airabinovich/java_petri_engine/32)
<!-- Reviewable:end -->
