### PR TITLE
Enhancement #51. Ability to create policies ordered by name

### DIFF
--- a/src/org/unc/lac/javapetriconcurrencymonitor/monitor/policies/FirstInLinePolicy.java
+++ b/src/org/unc/lac/javapetriconcurrencymonitor/monitor/policies/FirstInLinePolicy.java
@@ -1,10 +1,16 @@
 package org.unc.lac.javapetriconcurrencymonitor.monitor.policies;
 
+import org.unc.lac.javapetriconcurrencymonitor.petrinets.PetriNet;
+
 /**
- * Implements the TransitionsPolicy interface and decides based on the first transition found;
+ * Extends the TransitionsPolicy abstract class and decides based on the first transition found;
  *
  */
-public class FirstInLinePolicy implements TransitionsPolicy {
+public class FirstInLinePolicy extends TransitionsPolicy {
+
+	public FirstInLinePolicy(PetriNet _petri) {
+		super(_petri);
+	}
 
 	@Override
 	public int which(boolean[] enabled){

--- a/src/org/unc/lac/javapetriconcurrencymonitor/monitor/policies/RandomPolicy.java
+++ b/src/org/unc/lac/javapetriconcurrencymonitor/monitor/policies/RandomPolicy.java
@@ -2,29 +2,32 @@ package org.unc.lac.javapetriconcurrencymonitor.monitor.policies;
 
 import java.util.Random;
 
+import org.unc.lac.javapetriconcurrencymonitor.petrinets.PetriNet;
+
 /**
- * Implements the TransitionsPolicy interface and decides based on a random number generator
+ * Extends the TransitionsPolicy abstract class and decides based on a random number generator
  *
  */
-public class RandomPolicy implements TransitionsPolicy {
+public class RandomPolicy extends TransitionsPolicy {
 
 	private Random random_generator;
 	
-	public RandomPolicy(){
+	public RandomPolicy(PetriNet _petri){
+		super(_petri);
 		random_generator = new Random(System.currentTimeMillis());
 	}
 	
 	@Override
 	public int which(boolean[] enabled) {
 		int index;
-		int retries = enabled.length * 2;
+		int retries = enabled.length * 3;
 		do{
 			retries--;
-			index = random_generator.nextInt(enabled.length + 1);
 			if(retries < 0){
 				return -1;
 			}
-		}while(!enabled[index]);
+			index = random_generator.nextInt(enabled.length);
+		} while(!enabled[index]);
 		
 		return index;
 	}

--- a/src/org/unc/lac/javapetriconcurrencymonitor/monitor/policies/TransitionsPolicy.java
+++ b/src/org/unc/lac/javapetriconcurrencymonitor/monitor/policies/TransitionsPolicy.java
@@ -1,17 +1,28 @@
 package org.unc.lac.javapetriconcurrencymonitor.monitor.policies;
 
+import org.unc.lac.javapetriconcurrencymonitor.petrinets.PetriNet;
+
 /**
  * Transitions Policy. Used for condition variables in Monitor
  *
  */
-public interface TransitionsPolicy {
-	
+public abstract class TransitionsPolicy {
+
 	/**
-	 * Given an array of booleans specifying the transition ready te be fired,
+	 * PetriNet field is useful for defining custom policies based on transitions name or other parameters.
+	 */
+	protected PetriNet petri;
+
+	/**
+	 * Given an array of booleans specifying the transition ready to be fired,
 	 * the policy decides which should be fired
 	 * @param enabled an array of boolean containing true if the matching transition is ready to be fired
 	 * @return the transition to fire or -1 if none is enabled
 	 */
-	public int which(boolean[] enabled);
-	
+	public abstract int which(boolean[] enabled);
+
+	public TransitionsPolicy(PetriNet _petri) {
+		this.petri = _petri;
+	}
+
 }

--- a/test/org/lac/javapetriconcurrencymonitor/test/cases/PetriMonitorTestSuite.java
+++ b/test/org/lac/javapetriconcurrencymonitor/test/cases/PetriMonitorTestSuite.java
@@ -10,11 +10,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.lac.javapetriconcurrencymonitor.test.utils.TransitionEventObserver;
 import org.unc.lac.javapetriconcurrencymonitor.errors.IllegalTransitionFiringError;
-import org.unc.lac.javapetriconcurrencymonitor.exceptions.NotInitializedPetriNetException;
 import org.unc.lac.javapetriconcurrencymonitor.exceptions.PetriNetException;
 import org.unc.lac.javapetriconcurrencymonitor.monitor.PetriMonitor;
 import org.unc.lac.javapetriconcurrencymonitor.monitor.policies.FirstInLinePolicy;
-import org.unc.lac.javapetriconcurrencymonitor.monitor.policies.TransitionsPolicy;
 import org.unc.lac.javapetriconcurrencymonitor.petrinets.PetriNet;
 import org.unc.lac.javapetriconcurrencymonitor.petrinets.components.Transition;
 import org.unc.lac.javapetriconcurrencymonitor.petrinets.factory.PetriNetFactory;
@@ -29,7 +27,6 @@ public class PetriMonitorTestSuite {
 	
 	PetriMonitor monitor;
 	PetriNet petri;
-	static TransitionsPolicy policy;
 	static PetriNetFactory factory;
 	
 	static ObjectMapper jsonParser;
@@ -47,7 +44,6 @@ public class PetriMonitorTestSuite {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		policy = new FirstInLinePolicy();
 		jsonParser = new ObjectMapper();
 	}
 
@@ -59,7 +55,7 @@ public class PetriMonitorTestSuite {
 	private void setUpMonitor(String PNML, petriNetType type){
 		factory = new PetriNetFactory(PNML);
 		petri = factory.makePetriNet(type);
-		monitor = new PetriMonitor(petri, policy);
+		monitor = new PetriMonitor(petri, new FirstInLinePolicy(petri));
 		petri.initializePetriNet();
 	}
 	
@@ -302,7 +298,7 @@ public class PetriMonitorTestSuite {
 	@Test
 	public void testCreatingMonitorWithoutPetriShouldThrowException(){
 		try{
-			PetriMonitor aMonitor = new PetriMonitor(null, policy);
+			PetriMonitor aMonitor = new PetriMonitor(null, new FirstInLinePolicy(petri));
 			Assert.fail("An exception should've been thrown before this point");
 		} catch (Exception e){
 			Assert.assertEquals("IllegalArgumentException", e.getClass().getSimpleName());

--- a/test/org/lac/javapetriconcurrencymonitor/test/cases/PetriMonitorTimeTestSuite.java
+++ b/test/org/lac/javapetriconcurrencymonitor/test/cases/PetriMonitorTimeTestSuite.java
@@ -27,7 +27,6 @@ public class PetriMonitorTimeTestSuite {
 	PetriMonitor monitor;
 	TimedPetriNet timedPetriNet;
 	static ObjectMapper jsonParser;
-	static TransitionsPolicy policy;
 	static PetriNetFactory factory;
 	
 	private static final String ID = "id";
@@ -40,7 +39,6 @@ public class PetriMonitorTimeTestSuite {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		policy = new FirstInLinePolicy();
 		jsonParser = new ObjectMapper();
 	}
 
@@ -52,7 +50,7 @@ public class PetriMonitorTimeTestSuite {
 	private void setUpMonitor(String PNML){
 		factory = new PetriNetFactory(PNML);
 		timedPetriNet = (TimedPetriNet) factory.makePetriNet(petriNetType.TIMED);
-		monitor = new PetriMonitor(timedPetriNet, policy);
+		monitor = new PetriMonitor(timedPetriNet, new FirstInLinePolicy(timedPetriNet));
 	}
 	
 	/**


### PR DESCRIPTION
TransitionsPolicy is now an abstract class to force other policies to pass a PetriNet. This gives more flexibility to custom policies, e.g: order transition priority by name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/airabinovich/java_petri_engine/52)
<!-- Reviewable:end -->
